### PR TITLE
Fix stopping Bluetooth stack before TFT upload

### DIFF
--- a/esphome/nspanel_esphome_addon_upload_tft.yaml
+++ b/esphome/nspanel_esphome_addon_upload_tft.yaml
@@ -244,11 +244,11 @@ script:
           condition:
             - lambda: |-
                 // Any of the BT components
-                #if defined(USE_ESP32_BLE_TRACKER) || defined(USE_ESP32_BLE_SERVER) || defined(USE_BLUETOOTH_PROXY)
+                #if defined(USE_ESP32_BLE_CLIENT) || defined(USE_ESP32_BLE_SERVER) || defined(USE_BLUETOOTH_PROXY)
                 return true;
                 #else
                 return false;
-                #endif  // USE_ESP32_BLE_TRACKER || USE_ESP32_BLE_SERVER || USE_BLUETOOTH_PROXY
+                #endif  // USE_ESP32_BLE_CLIENT || USE_ESP32_BLE_SERVER || USE_BLUETOOTH_PROXY
           then:
             - lambda: |-
                 ESP_LOGI("${TAG_UPLOAD_TFT}", "Stopping Bluetooth stack to free memory for TFT upload");
@@ -278,7 +278,7 @@ script:
 
             - lambda: |-
                 // BLE tracker
-                #ifdef USE_ESP32_BLE_TRACKER
+                #ifdef USE_ESP32_BLE_CLIENT
                 App.feed_wdt();
                 // Stop BLE tracker scanning if active
                 auto *tracker = esp32_ble_tracker::global_esp32_ble_tracker;
@@ -292,14 +292,14 @@ script:
                 }
                 #else
                 ESP_LOGD("${TAG_UPLOAD_TFT}", "BLE tracker component not present");
-                #endif  // USE_ESP32_BLE_TRACKER
+                #endif  // USE_ESP32_BLE_CLIENT
             - delay: !lambda |-
                         // BLE tracker
-                        #ifdef USE_ESP32_BLE_TRACKER
+                        #ifdef USE_ESP32_BLE_CLIENT
                         return 2000;
                         #else
                         return 0;
-                        #endif  // USE_ESP32_BLE_TRACKER
+                        #endif  // USE_ESP32_BLE_CLIENT
 
             - lambda: |-
                 // BLE server


### PR DESCRIPTION
https://github.com/esphome/esphome/blob/4a529003527b3d475742b29ae2fed82e55b0066c/esphome/components/esp32_ble_tracker/__init__.py#L332

https://github.com/Blackymas/NSPanel_HA_Blueprint/issues/3223#issuecomment-3947326557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal Bluetooth configuration settings in the TFT upload script for better compatibility. This is a technical adjustment with no changes to the public interface or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->