### PR TITLE
Adjust device_name to nspanel_name in blueprint

### DIFF
--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -8748,7 +8748,7 @@ action:
                               - variables:
                                   climate_chip_visibility: !input climate_chip_visibility
                               - *delay_boot
-                              - action: 'esphome.{{ device_name }}_component_val'
+                              - action: 'esphome.{{ nspanel_name }}_component_val'
                                 data:
                                   page: mem
                                   id: climate_chip_visibility


### PR DESCRIPTION
This fixes a issue where the generated action name does not match the name of the service call

In my example. device_name: "nspanel-livingroom" & friendly_name: "Living Room NSPanel"

However the call generated by the blueprint shows "living_room_nspanel_component_val" 

Checking the blueprint i could see the variable in the action was set to "esphome.{{ device_name }}_component_val" and the actual action within developer tools -> actions was nspanel_livingroom_component_val

By using device_name as the variable it will use the name of the device in home assistant which defaults to the friendly_name. 

The PR changes this value to nspanel_name which uses the actual name of the service and so will match the service call. 





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed climate component visibility handling on the Home page to correctly target the NSPanel instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->