### PR TITLE
Fix mixed versioning between blueprint and TFT

### DIFF
--- a/esphome/nspanel_esphome_version.yaml
+++ b/esphome/nspanel_esphome_version.yaml
@@ -11,7 +11,7 @@ substitutions:
   # Value is imported from versioning/version.yaml
   <<: !include ../versioning/version.yaml
   # Minimum required versions for compatibility
-  min_blueprint_version: 7
+  min_blueprint_version: 8
   min_tft_version: 8
   min_esphome_compiler_version: 2026.1.0
   TAG_VERSIONING: nspanel.versioning

--- a/hmi/dev/ui/generate_pics_all.cmd
+++ b/hmi/dev/ui/generate_pics_all.cmd
@@ -1,0 +1,6 @@
+bash ../scripts/generate_images.sh pics/0.png eu
+bash ../scripts/generate_images.sh pics/0-portrait.png us
+bash ../scripts/generate_images.sh pics/0-white.png eu-white
+bash ../scripts/generate_images.sh pics/0-portrait-white.png us-white
+
+

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -11,7 +11,7 @@ blueprint:
   description: >
     # NSPanel Easy Configuration via Blueprint
 
-    **Blueprint release**: 7
+    **Blueprint release**: 8
 
 
     This project enables comprehensive configuration of your NSPanel through a Blueprint featuring a user interface.
@@ -4114,7 +4114,7 @@ trigger_variables:
     }}
 
 variables:
-  blueprint_version: 7
+  blueprint_version: 8
   pages:
     current: '{{ states(currentpage) }}'
     alarm: "alarm"


### PR DESCRIPTION
https://discord.com/channels/1464682227068698724/1479841242245239057/1480245696006459476

Fixes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Blueprint minimum version requirement increased from version 7 to version 8. Verify your system meets this requirement before proceeding with the update.

* **New Features**
  * Added image generation functionality supporting multiple UI layout variants and locale options, including both standard and white theme variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->