### PR TITLE
Fix a typo in Hebrew localization strings

### DIFF
--- a/esphome/nspanel_esphome_localization.yaml
+++ b/esphome/nspanel_esphome_localization.yaml
@@ -1485,7 +1485,7 @@ substitutions:
         sat: ש'
         sun: א'
       months:
-        jan: נאוני
+        jan: ראוני
         feb: ראורבפ
         mar: ץרמ
         apr: לירפא


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Hebrew translation for the January month name in localization configuration to ensure accurate display for Hebrew-speaking users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->