### PR TITLE
ci: Exempt Dependabot PRs from PR title validation

### DIFF
--- a/.github/workflows/esphome_build.yml
+++ b/.github/workflows/esphome_build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Detect changed files
         id: changed
         if: github.event_name == 'pull_request'
-        uses: step-security/changed-files@v47.0.1
+        uses: step-security/changed-files@v47.0.5
         with:
           files: |
             nspanel_esphome*.yaml

--- a/.github/workflows/esphome_build.yml
+++ b/.github/workflows/esphome_build.yml
@@ -99,6 +99,7 @@ jobs:
     if: needs.changes.outputs.any_changed == 'true' || github.event_name != 'pull_request'
     strategy:
       fail-fast: false
+      max-parallel: 8
       matrix:
         firmware:
           - name: Basic (IDF)
@@ -144,6 +145,7 @@ jobs:
     if: needs.changes.outputs.any_changed == 'true' || github.event_name != 'pull_request'
     strategy:
       fail-fast: false
+      max-parallel: 8
       matrix:
         firmware:
           - name: Basic (IDF)

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Detect changed shell scripts
         id: changed
         if: github.event_name == 'pull_request'
-        uses: step-security/changed-files@v47.0.1
+        uses: step-security/changed-files@v47.0.5
         with:
           files: '**/*.sh'
 

--- a/.github/workflows/validate_blueprint.yml
+++ b/.github/workflows/validate_blueprint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Get changed files
         id: changed
         if: github.event_name == 'pull_request'
-        uses: step-security/changed-files@v47.0.1
+        uses: step-security/changed-files@v47.0.5
         with:
           files: 'nspanel_easy_blueprint.yaml'
 

--- a/.github/workflows/validate_clang_format.yml
+++ b/.github/workflows/validate_clang_format.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Detect changed C/C++ files
         id: changed
         if: github.event_name == 'pull_request'
-        uses: step-security/changed-files@v47.0.1
+        uses: step-security/changed-files@v47.0.5
         with:
           files: |
             **/*.h

--- a/.github/workflows/validate_markdown.yml
+++ b/.github/workflows/validate_markdown.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Detect changed Markdown files
         id: changed
         if: github.event_name == 'pull_request'
-        uses: step-security/changed-files@v47.0.1
+        uses: step-security/changed-files@v47.0.5
         with:
           files: '**/*.md'
 

--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -42,7 +42,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     # Dependabot PRs are exempt — their titles follow Dependabot's own format.
-    if: github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Check title format
         env:

--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -15,6 +15,9 @@
 #   - synchronize : new commits pushed (title may have been corrected)
 #   - reopened    : PR reopened after being closed
 #
+# Dependabot PRs are exempt — their titles follow Dependabot's own format
+# which cannot be customised to match this convention.
+#
 # To enforce this as a merge gate, add "Validate PR title / All checks passed"
 # to the list of required status checks in the branch protection rules for `main`.
 
@@ -38,6 +41,8 @@ jobs:
   validate:
     name: Validate PR title
     runs-on: ubuntu-latest
+    # Dependabot PRs are exempt — their titles follow Dependabot's own format.
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Check title format
         env:
@@ -76,6 +81,7 @@ jobs:
   all-checks-passed:
     name: Validate PR title / All checks passed
     runs-on: ubuntu-latest
+    permissions: {}
     needs: validate
     if: always()
     steps:

--- a/.github/workflows/validate_python.yml
+++ b/.github/workflows/validate_python.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Detect changed Python files
         id: changed
         if: github.event_name == 'pull_request'
-        uses: step-security/changed-files@v47.0.1
+        uses: step-security/changed-files@v47.0.5
         with:
           files: '**/*.py'
 

--- a/.github/workflows/validate_yamllint.yml
+++ b/.github/workflows/validate_yamllint.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Identify changed files
-        uses: step-security/changed-files@v47.0.1
+        uses: step-security/changed-files@v47.0.5
         id: changed-files
         with:
           files: |

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Get PR information
         id: pr_info
         if: steps.skip_check.outputs.skip == 'false'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             try {


### PR DESCRIPTION
Dependabot PR titles follow its own format (e.g. "ci: bump actions/foo from 1 to 2") which cannot be customised to match the project's convention of requiring a capital letter after the prefix.

Adds `if: github.actor != 'dependabot[bot]'` to the `validate` job in `validate_pr_title.yml` so the check is skipped for Dependabot PRs. The gate job already treats `skipped` as success, so branch protection is unaffected.

Also adds the missing `permissions: {}` to the gate job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations for improved automation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->