### PR TITLE
ci: Force-push bump branch to handle re-runs

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -329,7 +329,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git push origin "${{ steps.commit.outputs.bump_branch }}"
+          git push origin "${{ steps.commit.outputs.bump_branch }}" --force
 
   # ---------------------------------------------------------------------------
   # Build pre-built firmware: nspanel-easy


### PR DESCRIPTION
The bump branch (ci/bump-version-*) may already exist remotely if a previous workflow run failed after pushing the branch but before the PR was opened or merged.

Adds --force to the push step so re-runs always overwrite the stale remote branch cleanly. Safe because these branches are ephemeral and never worked on directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD versioning workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->