### PR TITLE
improve: Remove `upload_tft` and `wake_up` API actions from default registration to reduce boot memory usage

### DIFF
--- a/docs/addon_upload_tft.md
+++ b/docs/addon_upload_tft.md
@@ -108,7 +108,7 @@ The following keys are available to be used in your `substitutions`:
 | `upload_tft_wait_ms_after_boot` | Optional | Positive integer (milliseconds) | `300000` (5 min) | Time to wait after the first NTP time sync before starting an automatic TFT upload. This delay allows the system to stabilize after boot. Reduce for faster updates; increase if you experience boot instability. |
 | `nextion_update_base_url` | Optional | Valid HTTP/HTTPS base URL | `https://raw.githubusercontent.com/edwardtfn/NSPanel-Easy/v${version}/hmi` | Base URL used when building the TFT download URL automatically. Override this to host TFT files on a local server while still benefiting from automatic model and version selection. |
 | `nextion_update_url` | Optional | Valid HTTP/HTTPS URL | _(empty)_ | Full URL override for the TFT file. When set, this takes absolute priority. The model selector and version logic are completely bypassed and this URL is used as-is. Use only when you need full control over the TFT source, such as for custom TFT files. See [important note below](#nextion_update_url-behaviour). |
-| `include_action_upload_tft` | Optional | `"true"` or `"false"` | `"false"` | When set to `"true"`, registers the `upload_tft` API action, allowing the TFT upload to be triggered from Home Assistant scripts or automations via `esphome.<panel>_upload_tft`. Disabled by default to reduce memory usage at boot. See [important note below](#include_action_upload_tft-behaviour). |
+| `include_action_upload_tft` | Optional | `true` or `false` | `false` | When set to `true`, registers the `upload_tft` API action, allowing the TFT upload to be triggered from Home Assistant scripts or automations via `esphome.<panel>_upload_tft`. Disabled by default to reduce memory usage at boot. See [important note below](#include_action_upload_tft-behaviour). |
 <!-- markdownlint-enable MD013 -->
 
 ### `nextion_update_url` behaviour
@@ -131,17 +131,17 @@ the recommended configuration for most users.
 > memory-intensive configurations (e.g. Bluetooth Proxy). Registering API actions consumes
 > heap memory at boot; disabling unused actions recovers that memory.
 
-When set to `"false"` (the default), the `upload_tft` API action is not registered.
+When set to `false` (the default), the `upload_tft` API action is not registered.
 All other functionality of this add-on remains fully operational: automatic TFT upload on
 version mismatch, the "Update TFT display" button in Home Assistant, and baud rate negotiation
 are all unaffected.
 
-Set this to `"true"` only if you need to trigger TFT uploads programmatically from Home
+Set this to `true` only if you need to trigger TFT uploads programmatically from Home
 Assistant scripts or automations using the `esphome.<panel>_upload_tft` service call.
 
 > [!IMPORTANT]
 > If you were previously calling `esphome.<panel>_upload_tft` from an automation or script,
-> add `include_action_upload_tft: "true"` to your substitutions to restore that behaviour.
+> add `include_action_upload_tft: true` to your substitutions to restore that behaviour.
 > This is a breaking change introduced to improve boot stability on memory-constrained devices.
 
 ### Display model options

--- a/docs/addon_upload_tft.md
+++ b/docs/addon_upload_tft.md
@@ -108,6 +108,7 @@ The following keys are available to be used in your `substitutions`:
 | `upload_tft_wait_ms_after_boot` | Optional | Positive integer (milliseconds) | `300000` (5 min) | Time to wait after the first NTP time sync before starting an automatic TFT upload. This delay allows the system to stabilize after boot. Reduce for faster updates; increase if you experience boot instability. |
 | `nextion_update_base_url` | Optional | Valid HTTP/HTTPS base URL | `https://raw.githubusercontent.com/edwardtfn/NSPanel-Easy/v${version}/hmi` | Base URL used when building the TFT download URL automatically. Override this to host TFT files on a local server while still benefiting from automatic model and version selection. |
 | `nextion_update_url` | Optional | Valid HTTP/HTTPS URL | _(empty)_ | Full URL override for the TFT file. When set, this takes absolute priority. The model selector and version logic are completely bypassed and this URL is used as-is. Use only when you need full control over the TFT source, such as for custom TFT files. See [important note below](#nextion_update_url-behaviour). |
+| `include_action_upload_tft` | Optional | `"true"` or `"false"` | `"false"` | When set to `"true"`, registers the `upload_tft` API action, allowing the TFT upload to be triggered from Home Assistant scripts or automations via `esphome.<panel>_upload_tft`. Disabled by default to reduce memory usage at boot. See [important note below](#include_action_upload_tft-behaviour). |
 <!-- markdownlint-enable MD013 -->
 
 ### `nextion_update_url` behaviour
@@ -122,6 +123,26 @@ The following keys are available to be used in your `substitutions`:
 When `nextion_update_url` is left empty (the default), the add-on builds the download URL
 automatically from the selected **Display model** and the current firmware version. This is
 the recommended configuration for most users.
+
+### `include_action_upload_tft` behaviour
+
+> [!NOTE]
+> This substitution was introduced to address boot-time memory exhaustion on devices running
+> memory-intensive configurations (e.g. Bluetooth Proxy). Registering API actions consumes
+> heap memory at boot; disabling unused actions recovers that memory.
+
+When set to `"false"` (the default), the `upload_tft` API action is not registered.
+All other functionality of this add-on remains fully operational: automatic TFT upload on
+version mismatch, the "Update TFT display" button in Home Assistant, and baud rate negotiation
+are all unaffected.
+
+Set this to `"true"` only if you need to trigger TFT uploads programmatically from Home
+Assistant scripts or automations using the `esphome.<panel>_upload_tft` service call.
+
+> [!IMPORTANT]
+> If you were previously calling `esphome.<panel>_upload_tft` from an automation or script,
+> add `include_action_upload_tft: "true"` to your substitutions to restore that behaviour.
+> This is a breaking change introduced to improve boot stability on memory-constrained devices.
 
 ### Display model options
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -552,15 +552,15 @@ standard panel functionality:
 
 | Action | Default | Re-enable with |
 | :- | :-: | :- |
-| `upload_tft` | excluded | `include_action_upload_tft: "true"` |
-| `wake_up` | excluded | `include_action_wake_up: "true"` |
+| `upload_tft` | excluded | `include_action_upload_tft: true` |
+| `wake_up` | excluded | `include_action_wake_up: true` |
 
 To re-enable one or both, add the corresponding substitution:
 
 ```yaml
 substitutions:
-  include_action_upload_tft: "true"  # Register the upload_tft API action
-  include_action_wake_up: "true"     # Register the wake_up API action
+  include_action_upload_tft: true  # Register the upload_tft API action
+  include_action_wake_up: true     # Register the wake_up API action
 ```
 
 **`upload_tft`** — triggers a TFT file upload from a specified URL. Not needed if you rely

--- a/docs/install.md
+++ b/docs/install.md
@@ -367,11 +367,10 @@ The options are:
   instructions. Useful for first-time installations to clear the Nextion Active Reparse Mode
   left by Sonoff's original firmware or other custom implementations before uploading the
   full TFT file.
-- **Use `nextion_update_url`:** Forces ESPHome to download the TFT file from the URL set
-  in your `nextion_update_url` substitution, bypassing automatic model and version selection
-  entirely. Use this only when serving a custom or locally hosted TFT file where you need
-  full control over the source. See the [Upload TFT Add-on documentation](addon_upload_tft.md)
-  for details.
+- **Custom TFT URL (`nextion_update_url` substitution):** If you set `nextion_update_url`,
+  ESPHome bypasses automatic model/version URL building and uses that exact file URL. This is
+  a configuration override, not a model-selector option. See the
+  [Upload TFT Add-on documentation](addon_upload_tft.md) for details.
 
 ### Uploading to Nextion
 
@@ -574,7 +573,7 @@ this service directly.
 > [!IMPORTANT]
 > If either of these actions has stopped appearing in Home Assistant after a firmware update
 > and you were calling them from automations or scripts, add the corresponding
-> `include_action_*: "true"` substitution to restore them. This is a deliberate breaking
+> `include_action_*: true` substitution to restore them. This is a deliberate breaking
 > change introduced to improve boot stability on memory-constrained devices.
 
 ##### Dynamic Memory Management

--- a/docs/install.md
+++ b/docs/install.md
@@ -152,16 +152,14 @@ Follow these steps to add a new device in the ESPHome Dashboard:
 10. For Wi-Fi credentials, use `!secret` for added security or input them directly.
 Learn about secrets in ESPHome: [Home Assistant Secrets in ESPHome](https://www.youtube.com/watch?v=eW4vKDeHh7Y).
 
-11. (Optional) Adjust `nextion_update_url` to the URL of a TFT file hosted on an HTTP or HTTPS server,
-    ensuring that the file is accessible to the NSPanel.
-    This URL will be used by ESPHome to download the TFT file to your panel.
-    For more information on hosting the TFT file and setting up the URL, see the [Upload TFT](#upload-tft) section.
+11. (Optional) If you need to serve TFT files from a local server instead of GitHub,
+    set `nextion_update_base_url` to your local server's base URL.
+    For full control over the TFT source (e.g. a custom TFT file), set `nextion_update_url` to the exact URL of the file.
+    For more information, see the [Upload TFT Add-on documentation](addon_upload_tft.md).
     > [!CAUTION]
-    > **Prefer HTTP over HTTPS for File Transfer**  
-    > While you might encounter examples using HTTPS in URLs for file transfer,
-    > it is strongly recommended to use HTTP, especially when employing the `arduino` framework.
-    > The support for HTTPS in this context can be unstable,
-    > often leading to issues with file transfers.
+    > **Prefer HTTP over HTTPS for file transfer**
+    > HTTPS support for TFT transfers can be unstable, particularly with the `arduino` framework.
+    > Use HTTP whenever possible for local servers.
 
 12. (Optional) Enhance security with API encryption by adding the copied key from step 6 to the **My Customization** area.
     > [!TIP]
@@ -360,20 +358,20 @@ Expand the **Update TFT display - Model** control and find the model that better
 
 The options are:
 
-- **Use `nextion_update_url`:** This will indicate ESPHome to download the TFT file from the URL
-you specified in your panel's yaml setting under the ESPHome dashboard and is typically used
-when your device have issues to transfer a TFT file directly from the GitHub repository or when
-you want to use a custom TFT file hosted in your local server.
-This is the default option and this keeps the compatibility with legacy installations when this was the only option.
-- **NSPanel Blank:** This is a very small TFT file which just shows a pre-formatted QR code on the screen with a link to the instructions.
-Although it's not a functional TFT for controlling your panel, it can be usefull when you have
-issues in your first TFT upload, as it will remove the *Nextion Active Reparse Mode* used when
-a Sonoff's TFT and also when some other custom implementations are installed.
-- **NSPanel EU:** This should be used when you are using a Sonoff NSPanel EU model.
-- **NSPanel US:** This should be used when you are using a Sonoff NSPanel US model
-installed on its normal (portrait) position with the buttons below the screen.
-- **NSPanel US Landscape:** This should be used when you are using a Sonoff NSPanel US model
-installed on the landscape position with the buttons at the right side of the screen.
+- **NSPanel EU:** Select this when using a Sonoff NSPanel EU model.
+- **NSPanel US:** Select this when using a Sonoff NSPanel US model installed in the normal
+  (portrait) position, with buttons below the screen.
+- **NSPanel US Landscape:** Select this when using a Sonoff NSPanel US model installed in
+  landscape position, with buttons at the right side of the screen.
+- **NSPanel Blank:** A minimal TFT file that displays a QR code linking to the setup
+  instructions. Useful for first-time installations to clear the Nextion Active Reparse Mode
+  left by Sonoff's original firmware or other custom implementations before uploading the
+  full TFT file.
+- **Use `nextion_update_url`:** Forces ESPHome to download the TFT file from the URL set
+  in your `nextion_update_url` substitution, bypassing automatic model and version selection
+  entirely. Use this only when serving a custom or locally hosted TFT file where you need
+  full control over the source. See the [Upload TFT Add-on documentation](addon_upload_tft.md)
+  for details.
 
 ### Uploading to Nextion
 
@@ -542,6 +540,40 @@ This approach allows you to:
 - Enable only required functionality
 - Temporarily disable memory-intensive components
 - Add custom components while maintaining core functionality
+
+##### Reducing Registered API Actions
+
+Each API action registered by ESPHome consumes heap memory at boot. On memory-constrained
+configurations — such as those running Bluetooth Proxy — this can cause boot instability or crashes.
+
+The Upload TFT add-on includes an `upload_tft` API action that allows triggering TFT uploads
+programmatically from Home Assistant scripts or automations. Most users never use this action
+directly; the "Update TFT display" button and automatic upload on boot cover all standard workflows.
+
+To exclude this action and recover the memory it would consume, set:
+
+```yaml
+substitutions:
+  include_action_upload_tft: "false"  # Default — action not registered, saves boot memory
+```
+
+If you do use the `esphome.<panel>_upload_tft` service call from your own automations or scripts,
+opt back in explicitly:
+
+```yaml
+substitutions:
+  include_action_upload_tft: "true"  # Register the upload_tft API action
+```
+
+> [!NOTE]
+> `include_action_upload_tft: "false"` is the default. Only automatic uploads on version
+> mismatch, the "Update TFT display" button, and baud rate negotiation are affected by this
+> flag — all other add-on functionality remains active regardless of this setting.
+
+> [!IMPORTANT]
+> If you were previously calling `esphome.<panel>_upload_tft` from a Home Assistant automation
+> or script and the action has stopped appearing after a firmware update, add
+> `include_action_upload_tft: "true"` to your substitutions to restore it.
 
 ##### Dynamic Memory Management
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -546,34 +546,36 @@ This approach allows you to:
 Each API action registered by ESPHome consumes heap memory at boot. On memory-constrained
 configurations — such as those running Bluetooth Proxy — this can cause boot instability or crashes.
 
-The Upload TFT add-on includes an `upload_tft` API action that allows triggering TFT uploads
-programmatically from Home Assistant scripts or automations. Most users never use this action
-directly; the "Update TFT display" button and automatic upload on boot cover all standard workflows.
+The following actions are excluded by default because most users never call them directly from
+Home Assistant scripts or automations, and excluding them recovers memory without affecting
+standard panel functionality:
 
-To exclude this action and recover the memory it would consume, set:
+| Action | Default | Re-enable with |
+| :- | :-: | :- |
+| `upload_tft` | excluded | `include_action_upload_tft: "true"` |
+| `wake_up` | excluded | `include_action_wake_up: "true"` |
 
-```yaml
-substitutions:
-  include_action_upload_tft: "false"  # Default — action not registered, saves boot memory
-```
-
-If you do use the `esphome.<panel>_upload_tft` service call from your own automations or scripts,
-opt back in explicitly:
+To re-enable one or both, add the corresponding substitution:
 
 ```yaml
 substitutions:
   include_action_upload_tft: "true"  # Register the upload_tft API action
+  include_action_wake_up: "true"     # Register the wake_up API action
 ```
 
-> [!NOTE]
-> `include_action_upload_tft: "false"` is the default. Only automatic uploads on version
-> mismatch, the "Update TFT display" button, and baud rate negotiation are affected by this
-> flag — all other add-on functionality remains active regardless of this setting.
+**`upload_tft`** — triggers a TFT file upload from a specified URL. Not needed if you rely
+on the "Update TFT display" button in Home Assistant or automatic upload on boot, which cover
+all standard workflows.
+
+**`wake_up`** — wakes the display from sleep and optionally resets the sleep and dimming
+timers. Not needed if your panel wakes on touch or via other automations that do not call
+this service directly.
 
 > [!IMPORTANT]
-> If you were previously calling `esphome.<panel>_upload_tft` from a Home Assistant automation
-> or script and the action has stopped appearing after a firmware update, add
-> `include_action_upload_tft: "true"` to your substitutions to restore it.
+> If either of these actions has stopped appearing in Home Assistant after a firmware update
+> and you were calling them from automations or scripts, add the corresponding
+> `include_action_*: "true"` substitution to restore them. This is a deliberate breaking
+> change introduced to improve boot stability on memory-constrained devices.
 
 ##### Dynamic Memory Management
 

--- a/docs/migration_from_blackymas.md
+++ b/docs/migration_from_blackymas.md
@@ -148,6 +148,7 @@ packages:
 | `ota_password` | It was set on the remote package to use your WiFi password | You have to add the substitution `ota_password: ${wifi_password}` for backward compatibility |
 | `language` | Selected via Blueprint dropdown | Set as `language: xx` substitution in ESPHome YAML - see [Localization](localization.md) |
 | `nextion_update_url` | Used to select the TFT model or override the URL | Now a full override only. Remove it unless you are hosting a custom TFT file locally |
+| `upload_tft` / `wake_up` API actions | Registered by default | Opt-in — add `include_action_upload_tft: true` and/or `include_action_wake_up: true` to your substitutions if needed |
 | `url` | `https://github.com/Blackymas/NSPanel_HA_Blueprint` | `https://github.com/edwardtfn/NSPanel-Easy` |
 | `ref` | `main` (or a specific version) | `latest` |
 | Add-on file paths | Root level (e.g. `nspanel_esphome_addon_climate_heat.yaml`) | Inside `esphome/` folder (e.g. `esphome/nspanel_esphome_addon_climate_heat.yaml`) |
@@ -411,3 +412,15 @@ A: Only if you are hosting a custom or local TFT file. If you set it to select y
 model in the Blackymas project, remove it. Model selection is now handled automatically
 by the **Display model** selector in Home Assistant. See the
 [TFT Upload Add-on documentation](addon_upload_tft.md) for details.
+
+**Q: Some API actions I was calling from automations are no longer available after migration.**
+A: The `upload_tft` and `wake_up` actions are no longer registered by default to reduce boot
+memory usage. Add the corresponding substitutions to your ESPHome YAML to restore them:
+
+```yaml
+substitutions:
+  include_action_upload_tft: true  # Restore the upload_tft API action
+  include_action_wake_up: true     # Restore the wake_up API action
+```
+
+See [Advanced Configuration](install.md#reducing-registered-api-actions) for details.

--- a/esphome/nspanel_esphome_addon_upload_tft.yaml
+++ b/esphome/nspanel_esphome_addon_upload_tft.yaml
@@ -18,42 +18,45 @@ substitutions:
   ##############################################
   TAG_UPLOAD_TFT: "nspanel.addon.upload_tft"
   DISPLAY_MODES_BLANK_TEXT: ${DISPLAY_MODES.BLANK.TEXT}
+  include_action_upload_tft: false
+  _pkg_action_upload_tft:  # To do: move this to an external package after v2024.6.0
+    api:
+      actions:
+        ##### TFT File Update Service: `upload_tft`
+        # Updates the panel's TFT file remotely from a specified URL or the default location, requiring the "Upload TFT" add-on.
+        # Usage: Essential for applying custom TFT designs or updates, especially when direct repository access is unavailable.
+        #
+        # Parameters:
+        # - `url` (string): URL for the TFT file. If "default" or empty, uses the URL from "Update TFT - Display Model" in Home Assistant settings.
+        #
+        # Example:
+        # service: esphome.<your_panel_name>_upload_tft
+        # data:
+        #   url: "http://homeassistant.local:8123/local/custom_tft_file.tft"  # Custom or default URL to the TFT file
+        #
+        # [!NOTE]
+        # Utilize "default" to automatically use the URL associated with the display model set in Home Assistant.
+        #
+        # [!ATTENTION]
+        # Requires the "Upload TFT" add-on for functionality.
+        - action: upload_tft
+          variables:
+            url: string
+          then:
+            - lambda: |-
+                if (!system_flags.tft_upload_active) {
+                  tft_upload_manual_request = true;
+                  upload_tft->execute(url.c_str());
+                }
+
+packages:
+  action_upload_tft: ${ _pkg_action_upload_tft if include_action_upload_tft else {} }
 
 esphome:
   platformio_options:
     build_flags:
       - -D NSPANEL_EASY_ADDON_UPLOAD_TFT
       - -D NSPANEL_EASY_ADDON_UPLOAD_TFT_AUTOMATICALLY=${1 if upload_tft_automatically else 0}
-
-# yamllint disable rule:comments-indentation
-api:
-  actions:
-    ##### TFT File Update Service: `upload_tft`
-    # Updates the panel's TFT file remotely from a specified URL or the default location, requiring the "Upload TFT" add-on.
-    # Usage: Essential for applying custom TFT designs or updates, especially when direct repository access is unavailable.
-    #
-    # Parameters:
-    # - `url` (string): URL for the TFT file. If "default" or empty, uses the URL from "Update TFT - Display Model" in Home Assistant settings.
-    #
-    # Example:
-    # service: esphome.<your_panel_name>_upload_tft
-    # data:
-    #   url: "http://homeassistant.local:8123/local/custom_tft_file.tft"  # Custom or default URL to the TFT file
-    #
-    # [!NOTE]
-    # Utilize "default" to automatically use the URL associated with the display model set in Home Assistant.
-    #
-    # [!ATTENTION]
-    # Requires the "Upload TFT" add-on for functionality.
-    - action: upload_tft
-      variables:
-        url: string
-      then:
-        - lambda: |-
-            if (!system_flags.tft_upload_active) {
-              tft_upload_manual_request = true;
-              upload_tft->execute(url.c_str());
-            }
 
 button:
   ##### UPDATE TFT DISPLAY #####

--- a/esphome/nspanel_esphome_hw_display.yaml
+++ b/esphome/nspanel_esphome_hw_display.yaml
@@ -74,15 +74,19 @@ substitutions:
       TEXT: "NSpanel Easy US Landscape (Under construction)"
 
   TAG_HW_DISPLAY: nspanel.hw.display
+  include_action_wake_up: false
+  _pkg_action_wake_up:
+    api:
+      actions:
+        # Wake Up Service
+        - action: wake_up
+          variables:
+            reset_timer: bool  # Determines whether to reset the sleep and dimming timers upon waking the display.
+          then:
+            - lambda: wakeup->execute(reset_timer);
 
-api:
-  actions:
-    # Wake Up Service
-    - action: wake_up
-      variables:
-        reset_timer: bool  # Determines whether to reset the sleep and dimming timers upon waking the display.
-      then:
-        - lambda: wakeup->execute(reset_timer);
+packages:
+  action_wake_up: ${ _pkg_action_wake_up if include_action_wake_up else {} }
 
 binary_sensor:
   - id: nextion_init  # Delays initial info from HA to the display

--- a/esphome/nspanel_esphome_version.yaml
+++ b/esphome/nspanel_esphome_version.yaml
@@ -14,7 +14,7 @@ substitutions:
   # Minimum required blueprint version for compatibility
   # Select 'next' or '${version}' when you change the "contract" between ESPHome and Blueprint
   # Versioning workflow will replace this by the new version being generated
-  min_blueprint_version: 2026.4.12
+  min_blueprint_version: ${version}
 
   # Minimum required TFT version for compatibility
   # Must be manually updated with Nextion Editor

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -3804,7 +3804,12 @@ blueprint:
           selector: *color_selector
         wake_up_sensors:
           name: Wake-up sensors
-          description: "Select a sensors to wake-up the panel when the sensor turns `On`."
+          description: >-
+            `Optional`
+
+            Select sensors to wake up the panel when the sensor turns `On`.
+
+            **Important:** Requires `include_action_wake_up: true` in your panel's ESPHome YAML substitutions.
           default: &selector_entity_multiple_default_empty []
           selector:
             entity:

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -6,7 +6,7 @@
 ##################################################################################################
 ---
 blueprint:
-  name: NSPanel Easy Configuration (v2026.4.13)
+  name: NSPanel Easy Configuration (v9999.99.9)
   author: Edward Firmo (https://github.com/edwardtfn)
   description: >
     # NSPanel Easy Configuration via Blueprint
@@ -4052,7 +4052,7 @@ trigger_variables:
     }}
 
 variables:
-  blueprint_version: 2026.4.13
+  blueprint_version: 9999.99.9
   pages:
     current: '{{ states(currentpage) }}'
     alarm: "alarm"


### PR DESCRIPTION
Two API actions previously registered by default are now opt-in: `upload_tft` and `wake_up`.

Each action registered at boot consumes heap memory. On memory-constrained configurations — such as panels running Bluetooth Proxy — this was causing boot instability and crashes. Since most users never call these actions directly from Home Assistant automations or scripts, excluding them by default recovers memory with no impact on standard functionality.

## What changed

- `esphome.<panel>_upload_tft` and `esphome.<panel>_wake_up` no longer appear in Home Assistant by default.
- All other functionality is unaffected: automatic TFT upload on version mismatch, the "Update TFT display" button, display wake on touch, and sleep/dimming timers all continue to work as before.

## Action required

If you call either of these actions from a Home Assistant automation or script, add the corresponding substitution to your ESPHome YAML to restore it:

```yaml
substitutions:
  include_action_upload_tft: true  # Restore the upload_tft API action
  include_action_wake_up: true     # Restore the wake_up API action
```

For full details, see the [Advanced Configuration](docs/install.md#reducing-registered-api-actions) section in the documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features / Behavior**
  * `upload_tft` and `wake_up` API actions are not registered by default; opt-in substitutions are available to re-enable them (note: restoring may require updating automations).

* **Documentation**
  * Clarified TFT download/setup for local servers and renamed related references.
  * Shortened transport-security guidance for TFT transfers.
  * Reworded “Update TFT display - Model” option descriptions and added a “Reducing Registered API Actions” section with migration steps.

* **Chores**
  * Blueprint version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->