### PR TITLE
improve: Reduce command pacing defaults for faster display rendering

### DIFF
--- a/esphome/nspanel_esphome_addon_display_light.yaml
+++ b/esphome/nspanel_esphome_addon_display_light.yaml
@@ -22,6 +22,7 @@ light:
     platform: monochromatic
     output: display_output
     default_transition_length: 0s
+    gamma_correct: 0
     on_turn_on:
       then:
         - lambda: |-

--- a/esphome/nspanel_esphome_addon_upload_tft.yaml
+++ b/esphome/nspanel_esphome_addon_upload_tft.yaml
@@ -140,9 +140,11 @@ script:
           timeout: 10s
       - delay: 2s
       - lambda: |-
-          ESP_LOGD("${TAG_UPLOAD_TFT}", "Starting TFT upload");
-          tft_upload_result = disp1->upload_tft(${upload_tft_baud_rate}, !disp1->is_setup());
-          ESP_LOGV("${TAG_UPLOAD_TFT}", "TFT upload: %s", YESNO(tft_upload_result));
+          const uint32_t upload_baud = system_flags.baud_fallback_active
+              ? static_cast<uint32_t>(${BAUD_RATE_FALLBACK})
+              : static_cast<uint32_t>(${upload_tft_baud_rate});
+          ESP_LOGD("${TAG_UPLOAD_TFT}", "Starting TFT upload at %" PRIu32 " bps", upload_baud);
+          tft_upload_result = disp1->upload_tft(upload_baud, !disp1->is_setup());
 
   - id: !extend stop_all
     then:

--- a/esphome/nspanel_esphome_hw_buttons.yaml
+++ b/esphome/nspanel_esphome_hw_buttons.yaml
@@ -35,17 +35,19 @@ binary_sensor:
         invalid_cooldown: ${invalid_cooldown}
         then:
           - lambda: |-
-              ESP_LOGD("${TAG_HW_BUTTONS}", "Left button - Long click");
+              ESP_LOGV("${TAG_HW_BUTTONS}", "Left button - Long click detected");
               button_left_press_long->execute();
               ha_button->execute(page_names[current_page_id], "hw_bt_left", "long_click");
+              ESP_LOGD("${TAG_HW_BUTTONS}", "Left button - Long click dispatched");
       - timing: &short_click-timing
           - ON for at most 0.8s
         invalid_cooldown: ${invalid_cooldown}
         then:
           - lambda: |-
-              ESP_LOGD("${TAG_HW_BUTTONS}", "Left button - Short click");
+              ESP_LOGV("${TAG_HW_BUTTONS}", "Left button - Short click detected");
               button_left_press_short->execute();
               ha_button->execute(page_names[current_page_id], "hw_bt_left", "short_click");
+              ESP_LOGD("${TAG_HW_BUTTONS}", "Left button - Short click dispatched");
     on_release:
       then:
         - script.execute: button_left_release
@@ -59,16 +61,18 @@ binary_sensor:
         invalid_cooldown: ${invalid_cooldown}
         then:
           - lambda: |-
-              ESP_LOGD("${TAG_HW_BUTTONS}", "Right button - Long click");
+              ESP_LOGV("${TAG_HW_BUTTONS}", "Right button - Long click detected");
               button_right_press_long->execute();
               ha_button->execute(page_names[current_page_id], "hw_bt_right", "long_click");
+              ESP_LOGD("${TAG_HW_BUTTONS}", "Right button - Long click dispatched");
       - timing: *short_click-timing
         invalid_cooldown: ${invalid_cooldown}
         then:
           - lambda: |-
-              ESP_LOGD("${TAG_HW_BUTTONS}", "Right button - Short click");
+              ESP_LOGV("${TAG_HW_BUTTONS}", "Right button - Short click detected");
               button_right_press_short->execute();
               ha_button->execute(page_names[current_page_id], "hw_bt_right", "short_click");
+              ESP_LOGD("${TAG_HW_BUTTONS}", "Right button - Short click dispatched");
     on_release:
       then:
         - script.execute: button_right_release

--- a/esphome/nspanel_esphome_hw_display.yaml
+++ b/esphome/nspanel_esphome_hw_display.yaml
@@ -105,11 +105,8 @@ display:
   - id: disp1
     platform: nextion
     uart_id: tf_uart
-    command_spacing: 3ms
+    command_spacing: 1ms
     dump_device_info: true
-    # max_commands_per_loop: 15
-    # max_queue_age: 8000
-    # max_queue_size: 128  # Enable with v2026.6.0
     update_interval: never
     on_setup:
       then:

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -5902,6 +5902,10 @@ actions:
       # yamllint enable rule:truthy rule:line-length
       # yamllint enable rule:comments-indentation
 
+  - condition: '{{ nspanel_name is defined }}'
+  - condition: '{{ nspanel_name is string }}'
+  - condition: '{{ nspanel_name | length > 0 }}'
+
   - alias: Global anchor repository
     if: '{{ false }}'  # It should never execute directly
     then:

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -3919,8 +3919,8 @@ blueprint:
           description: >
             Delay between sequential Home Assistant service calls to the panel during the boot sequence.
             Boot involves a large burst of commands (settings, icons, component initialization),
-            so a slightly higher value than the runtime delay is needed to ensure reliable boot.
-            Values below ~25 ms have been observed to cause Nextion buffer overflows during boot.
+            so a slightly higher value than the runtime delay is a safe default.
+            The default of 50 ms works well for most setups.
             Values above 100 ms are rarely needed.
           default: 50
           selector:

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -6178,15 +6178,15 @@ actions:
                     sequence:
                       - alias: Blueprint version
                         sequence:
-                          - &delay_boot
-                            delay:
-                              milliseconds: !input delay_boot
                           - action: 'esphome.{{ nspanel_name }}_component_text'
                             data:
                               page: mem
                               id: ver_blueprint
                               txt: '{{ blueprint_version }}'
                             continue_on_error: true
+                          - &delay_boot
+                            delay:
+                              milliseconds: !input delay_boot
 
                       - &variables_hardware
                         variables:
@@ -6222,7 +6222,6 @@ actions:
                         sequence:
                           - alias: DateTime on page home
                             sequence:
-                              - *delay_boot
                               - alias: date_color
                                 action: 'esphome.{{ nspanel_name }}_component_color'
                                 data:
@@ -6254,6 +6253,7 @@ actions:
                                   id: time_format
                                   txt: !input time_format
                                 continue_on_error: true
+                              - *delay_boot
 
                       - alias: Home page
                         sequence:
@@ -6261,7 +6261,6 @@ actions:
                             sequence:
                               - variables:
                                   climate_chip_visibility: !input climate_chip_visibility
-                              - *delay_boot
                               - action: 'esphome.{{ nspanel_name }}_component_val'
                                 data:
                                   page: mem
@@ -6271,7 +6270,7 @@ actions:
                                     {%- elif climate_chip_visibility == 'never' %}2
                                     {%- else %}0{%- endif %}
                                 continue_on_error: true
-                          - *delay_boot
+                              - *delay_boot
                           - alias: chip_font
                             action: 'esphome.{{ nspanel_name }}_component_val'
                             data:
@@ -6295,11 +6294,11 @@ actions:
                               id: outdoor_temp_font
                               val: !input home_outdoor_temp_font
                             continue_on_error: true
+                          - *delay_boot
                           - alias: Home page - Entities button
                             sequence:
                               - variables:
                                   bt_entities_icon: !input home_button06_icon
-                              - *delay_boot
                               - alias: entities_pages_icon
                                 action: 'esphome.{{ nspanel_name }}_component_text'
                                 data:
@@ -6320,12 +6319,12 @@ actions:
                                   id: entities_pages_icon_color
                                   color: !input home_button06_icon_color
                                 continue_on_error: true
+                              - *delay_boot
                           - alias: Home page - Utilities button
                             sequence:
                               - variables:
                                   utilities_enabled: !input utilities_enabled
                                   bt_utilities_icon: !input home_button08_icon
-                              - *delay_boot
                               - alias: home_bt_utilities
                                 action: 'esphome.{{ nspanel_name }}_icon'
                                 data:
@@ -6339,6 +6338,7 @@ actions:
                                     }}
                                   icon_color: !input home_button08_icon_color
                                   visible: '{{ utilities_enabled }}'
+                              - *delay_boot
 
                       ###### Notification button ######
                       - &refresh_page_home_notification_button
@@ -6352,7 +6352,6 @@ actions:
                                   else [200, 204, 200]
                                 }}
                           ##### Home page - Notification icon (bt_notific) - Colors
-                          - *delay_boot
                           - action: 'esphome.{{ nspanel_name }}_component_color'
                             data:
                               page: mem
@@ -6366,9 +6365,9 @@ actions:
                               id: notification_icon_color_unread
                               color: !input home_button04_icon_color02
                             continue_on_error: true
+                          - *delay_boot
 
                           ##### Home page - Notification icon (bt_notific) - Icon
-                          - *delay_boot
                           - variables:
                               bt_notific_icon: !input home_button04_icon
                           - action: 'esphome.{{ nspanel_name }}_icon'
@@ -6384,20 +6383,20 @@ actions:
                               icon_color: '{{ bt_notific_icon_color }}'
                               visible: false
                             continue_on_error: true
+                          - *delay_boot
 
                       - alias: Home page - outdoor_temp
                         sequence:
-                          - *delay_boot
                           - action: 'esphome.{{ nspanel_name }}_component_color'
                             data:
                               page: home
                               id: outdoor_temp
                               color: !input home_outdoor_temp_label_color
                             continue_on_error: true
+                          - *delay_boot
 
                       - alias: Home page - indr_temp
                         sequence:
-                          - *delay_boot
                           - action: 'esphome.{{ nspanel_name }}_component_color'
                             data:
                               page: home
@@ -6423,6 +6422,7 @@ actions:
                               id: indr_temp_icon
                               color: !input home_indoor_temp_icon_color
                             continue_on_error: true
+                          - *delay_boot
 
                       - alias: Home page - Values 01 - 04
                         repeat:
@@ -6441,13 +6441,13 @@ actions:
                                 - '{{ repeat.item.label_color_rgb | count == 3 }}'
                                 - '{{ repeat.item.label_color_rgb != default_color }}'
                               then:
-                                - *delay_boot
                                 - action: 'esphome.{{ nspanel_name }}_component_color'
                                   data:
                                     page: home
                                     id: '{{ repeat.item.component }}'
                                     color: '{{ repeat.item.label_color_rgb }}'
                                   continue_on_error: true
+                                - *delay_boot
 
                             - alias: Icon color
                               if:
@@ -6456,13 +6456,13 @@ actions:
                                 - '{{ repeat.item.icon_color_rgb | count == 3 }}'
                                 - '{{ repeat.item.icon_color_rgb != default_color }}'
                               then:
-                                - *delay_boot
                                 - action: 'esphome.{{ nspanel_name }}_component_color'
                                   data:
                                     page: home
                                     id: '{{ repeat.item.component }}_icon'
                                     color: '{{ repeat.item.icon_color_rgb }}'
                                   continue_on_error: true
+                                - *delay_boot
 
                             - alias: Icon
                               if:
@@ -6471,57 +6471,56 @@ actions:
                                 - '{{ repeat.item.icon is match "mdi:" }}'
                                 - '{{ repeat.item.icon.split("mdi:")[1] in all_icons }}'
                               then:
-                                - *delay_boot
                                 - action: 'esphome.{{ nspanel_name }}_component_text'
                                   data:
                                     page: '{{ repeat.item.page }}'
                                     id: '{{ repeat.item.component }}_icon'
                                     txt: '{{ all_icons[repeat.item.icon.split("mdi:")[1]] }}'
                                   continue_on_error: true
+                                - *delay_boot
 
                       - alias: NSPanel Left Button Name
                         if: '{{ hardware.buttons.left.name | length > 0 }}'
                         then:
                           ### LABEL Font Color ###
-                          - *delay_boot
                           - action: 'esphome.{{ nspanel_name }}_component_color'
                             data:
                               page: home
                               id: left_bt_text
                               color: !input left_button_color
                             continue_on_error: true
-                          ### LABEL Font ###
                           - *delay_boot
+                          ### LABEL Font ###
                           - action: 'esphome.{{ nspanel_name }}_component_text'
                             data:
                               page: home
                               id: left_bt_text
                               txt: '{{ hardware.buttons.left.name }}'
                             continue_on_error: true
+                          - *delay_boot
 
                       - alias: NSPanel Right Button Name
                         if: '{{ hardware.buttons.right.name | length > 0 }}'
                         then:
                           ### LABEL Font Color ###
-                          - *delay_boot
                           - action: 'esphome.{{ nspanel_name }}_component_color'
                             data:
                               page: home
                               id: right_bt_text
                               color: !input right_button_color
                             continue_on_error: true
-                          ### LABEL Font ###
                           - *delay_boot
+                          ### LABEL Font ###
                           - action: 'esphome.{{ nspanel_name }}_component_text'
                             data:
                               page: home
                               id: right_bt_text
                               txt: '{{ hardware.buttons.right.name }}'
                             continue_on_error: true
+                          - *delay_boot
 
                       - alias: QRcode
                         sequence:
-                          - *delay_boot
                           - alias: qrcode_icon
                             sequence:
                               - variables:
@@ -6538,7 +6537,7 @@ actions:
                                       else all_icons["qrcode-scan"]
                                     }}
                                 continue_on_error: true
-                          - *delay_boot
+                              - *delay_boot
                           - alias: qrcode_icon_color
                             action: 'esphome.{{ nspanel_name }}_component_color'
                             data:
@@ -6546,6 +6545,7 @@ actions:
                               id: qrcode_icon_color
                               color: !input home_button05_icon_color
                             continue_on_error: true
+                          - *delay_boot
                           - &qrcode_update
                             alias: qrcode_update
                             sequence:
@@ -6562,13 +6562,13 @@ actions:
                                       else
                                         qrcode_fallback_value
                                     }}
-                              - *delay_boot
                               - action: 'esphome.{{ nspanel_name }}_qrcode'
                                 data:
                                   title: !input qrcode_label
                                   qrcode: '{{ qrcode_value }}'
                                   show: false
                                 continue_on_error: true
+                              - *delay_boot
 
                       - alias: Relay settings
                         sequence:
@@ -6580,7 +6580,6 @@ actions:
                               relay2_local_control: '{{ hardware.buttons.right.entity == relay02_entity }}'
                               relay2_fallback: !input relay_2_local_fallback
 
-                          - *delay_boot
                           - action: 'esphome.{{ nspanel_name }}_component_text'
                             data:
                               page: mem
@@ -6592,8 +6591,8 @@ actions:
                                   else all_icons["numeric-1-box-outline"]
                                 }}
                             continue_on_error: true
-
                           - *delay_boot
+
                           - action: 'esphome.{{ nspanel_name }}_component_text'
                             data:
                               page: mem
@@ -6605,24 +6604,24 @@ actions:
                                   else all_icons["numeric-2-box-outline"]
                                 }}
                             continue_on_error: true
-
                           - *delay_boot
+
                           - action: 'esphome.{{ nspanel_name }}_component_color'
                             data:
                               page: mem
                               id: relay1_icon_color
                               color: !input relay01_icon_color
                             continue_on_error: true
-
                           - *delay_boot
+
                           - action: 'esphome.{{ nspanel_name }}_component_color'
                             data:
                               page: mem
                               id: relay2_icon_color
                               color: !input relay02_icon_color
                             continue_on_error: true
-
                           - *delay_boot
+
                           - action: 'esphome.{{ nspanel_name }}_component_val'
                             data:
                               page: mem
@@ -6635,6 +6634,7 @@ actions:
                                   (relay2_fallback|int * 32)
                                 }}
                             continue_on_error: true
+                          - *delay_boot
 
                       - alias: Climate entity
                         sequence:
@@ -6642,13 +6642,13 @@ actions:
                               climate_entity_id_valid: '{{ climate is string and climate is match "climate." }}'
                               climate_friendly_name: '{{ state_attr(climate, "friendly_name") if climate_entity_id_valid else "" }}'
 
-                          - *delay_boot
                           - action: 'esphome.{{ nspanel_name }}_component_val'
                             data:
                               page: mem
                               id: is_climate
                               val: '{{ 1 if climate_entity_id_valid else 0 }}'
                             continue_on_error: true
+                          - *delay_boot
 
                           - alias: Climate friendly name
                             if:
@@ -6656,39 +6656,38 @@ actions:
                               - '{{ climate_entity_id_valid }}'
                               - '{{ state_attr(climate, "friendly_name") | string | length > 0 }}'
                             then:
-                              - *delay_boot
                               - action: 'esphome.{{ nspanel_name }}_component_text'
                                 data:
                                   page: mem
                                   id: addon_climate_friendly_name
                                   txt: '{{ climate_friendly_name if climate_friendly_name is string else "" }}'
                                 continue_on_error: true
+                              - *delay_boot
 
                           - alias: Embedded climate
                             sequence:
-                              - *delay_boot
                               - action: 'esphome.{{ nspanel_name }}_component_val'
                                 data:
                                   page: mem
                                   id: embedded_climate
                                   val: '{{ 1 if climate == thermostat_embedded else 0 }}'
                                 continue_on_error: true
+                              - *delay_boot
 
                           - alias: Embedded indoor temperature
                             sequence:
-                              - *delay_boot
                               - action: 'esphome.{{ nspanel_name }}_component_val'
                                 data:
                                   page: mem
                                   id: embedded_indoor_temperature
                                   val: '{{ 1 if embedded_indoor_temperature else 0 }}'
                                 continue_on_error: true
+                              - *delay_boot
 
                       - alias: Climate page
                         sequence:
                           - variables:
                               climate_page_button_font_size: !input climate_page_button_font_size
-                          - *delay_boot
                           - alias: climate_page_button_font_size
                             action: 'esphome.{{ nspanel_name }}_component_val'
                             data:
@@ -6696,26 +6695,26 @@ actions:
                               id: button_font
                               val: '{{ climate_page_button_font_size | int(8) }}'
                             continue_on_error: true
+                          - *delay_boot
 
                       - alias: HW Buttons settings
                         sequence:
-                          - *delay_boot
                           - action: 'esphome.{{ nspanel_name }}_component_color'
                             data:
                               page: mem
                               id: button_bar_color_on
                               color: !input hw_buttons_bar_color_on
                             continue_on_error: true
-
                           - *delay_boot
+
                           - action: 'esphome.{{ nspanel_name }}_component_color'
                             data:
                               page: mem
                               id: button_bar_color_off
                               color: !input hw_buttons_bar_color_off
                             continue_on_error: true
-
                           - *delay_boot
+
                           - action: 'esphome.{{ nspanel_name }}_component_val'
                             data:
                               page: mem
@@ -6727,8 +6726,8 @@ actions:
                                   hardware.buttons.left.entity_is_valid
                                 }}
                             continue_on_error: true
-
                           - *delay_boot
+
                           - action: 'esphome.{{ nspanel_name }}_component_val'
                             data:
                               page: mem
@@ -6740,18 +6739,19 @@ actions:
                                   hardware.buttons.right.entity_is_valid
                                 }}
                             continue_on_error: true
+                          - *delay_boot
 
                           - alias: hw_buttons_bars_pages
                             sequence:
                               - variables:
                                   hw_buttons_bars_pages: !input hw_buttons_bars_pages
-                              - *delay_boot
                               - action: 'esphome.{{ nspanel_name }}_component_val'
                                 data:
                                   page: mem
                                   id: buttons_bars_pages
                                   val: '{{ hw_buttons_bars_pages | map("int") | sum }}'
                                 continue_on_error: true
+                              - *delay_boot
 
                           - alias: Update Hardware buttons bars states
                             sequence:
@@ -6767,7 +6767,6 @@ actions:
                                       else (states(hardware.buttons.right.entity) | default("unavailable")
                                         if hardware.buttons.right.entity_is_valid else "unavailable")) in enum.states.on }}
                               # Send individual calls if the buttons have different states
-                              - *delay_boot
                               - action: 'esphome.{{ nspanel_name }}_component_val'
                                 data:
                                   page: mem
@@ -6781,87 +6780,87 @@ actions:
                                   id: hw_bt_right  # Right button
                                   val: '{{ 1 if hw_btn_right_state else 0 }}'
                                 continue_on_error: true
+                              - *delay_boot
 
                       - alias: Global settings - Decimal separator
                         sequence:
-                          - *delay_boot
                           - action: 'esphome.{{ nspanel_name }}_component_text'
                             data:
                               page: mem
                               id: decimal_separator
                               txt: !input decimal_separator
                             continue_on_error: true
-
                           - *delay_boot
+
                           - action: 'esphome.{{ nspanel_name }}_component_text'
                             data:
                               page: mem
                               id: temp_unit
                               txt: !input temperature_unit
                             continue_on_error: true
-
                           - *delay_boot
+
                           - action: 'esphome.{{ nspanel_name }}_component_val'
                             data:
                               page: mem
                               id: button_back_font
                               val: !input button_back_font_size
                             continue_on_error: true
+                          - *delay_boot
 
                       - alias: Entity pages alignment
                         sequence:
                           - variables:
                               entitypages_value_alignment: !input entitypages_value_alignment
-                          - *delay_boot
                           - action: 'esphome.{{ nspanel_name }}_component_val'
                             data:
                               page: mem
                               id: ent_value_xcen
                               val: '{{ int(entitypages_value_alignment) if is_number(entitypages_value_alignment) else 0 }}'
                             continue_on_error: true
+                          - *delay_boot
 
                       - alias: Screensaver settings
                         sequence:
                           - variables:
                               screensaver_display_time: !input screensaver_display_time
                               screensaver_time_font: !input screensaver_display_time_font_size
-                          - *delay_boot
                           - action: 'esphome.{{ nspanel_name }}_component_color'
                             data:
                               page: screensaver
                               id: text
                               color: !input screensaver_display_time_font_color
                             continue_on_error: true
-
                           - *delay_boot
+
                           - action: 'esphome.{{ nspanel_name }}_component_val'
                             data:
                               page: mem
                               id: screensaver_display_time
                               val: '{{ 1 if screensaver_display_time else 0 }}'
                             continue_on_error: true
-
                           - *delay_boot
+
                           - action: 'esphome.{{ nspanel_name }}_component_val'
                             data:
                               page: mem
                               id: screensaver_time_font
                               val: '{{ int(screensaver_time_font) }}'
                             continue_on_error: true
-
                           - *delay_boot
+
                           - action: 'esphome.{{ nspanel_name }}_component_color'
                             data:
                               page: mem
                               id: screensaver_bco
                               color: !input screensaver_background_color
                             continue_on_error: true
+                          - *delay_boot
 
                       - alias: Disable empty buttons pages
                         repeat:
                           for_each: '{{ pages.buttonpages }}'
                           sequence:
-                            - *delay_boot
                             - action: 'esphome.{{ nspanel_name }}_command'
                               data:
                                 cmd: >
@@ -6875,12 +6874,12 @@ actions:
                                   {% endfor %}
                                   is_{{ repeat.item }}={{ ns.mask }}
                               continue_on_error: true
+                            - *delay_boot
 
                       - alias: Disable empty entity pages
                         repeat:
                           for_each: '{{ pages.entitypages }}'
                           sequence:
-                            - *delay_boot
                             - action: 'esphome.{{ nspanel_name }}_command'
                               data:
                                 cmd: >
@@ -6897,6 +6896,7 @@ actions:
                                     else 0
                                   }}
                               continue_on_error: true
+                            - *delay_boot
 
                       - alias: Entity pages button visibility
                         action: 'esphome.{{ nspanel_name }}_component_val'
@@ -6913,7 +6913,6 @@ actions:
                             }}
                         continue_on_error: true
 
-              ##### Action call #####
               - alias: NSPanel action call
                 conditions:
                   - '{{ nspanel_event.type == "action_call" }}'
@@ -7030,7 +7029,6 @@ actions:
                       entity_id: '{{ nspanel_event.entity }}'
                     continue_on_error: true
 
-              ##### Page changed #####
               - alias: Page changed
                 conditions:
                   - '{{ nspanel_event.type == "page_changed"}}'
@@ -7044,7 +7042,6 @@ actions:
                           - variables:
                               page_constructor: true
                           ##### Weather Icon Home Page #####
-                          - *delay_default
                           - &refresh-page_home-weather_pic
                             action: 'esphome.{{ nspanel_name }}_component_val'
                             data:
@@ -7059,6 +7056,7 @@ actions:
                                   ] | default(1)
                                 }}
                             continue_on_error: true
+                          - *delay_default
 
                           ##### NSPanel Outdoor Temp #####
                           - &refresh-page_home-outdoor_temp
@@ -7114,13 +7112,13 @@ actions:
                                     {{ outdoor_temp | regex_replace('\s+', ' ') | trim }}
 
                               - condition: "{{ outdoor_temp_trimmed != '' }}"
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_component_text'
                                 data:
                                   page: home
                                   id: outdoor_temp
                                   txt: '{{ outdoor_temp_trimmed }}'
                                 continue_on_error: true
+                              - *delay_default
 
                           - &refresh_page_home_indoor_temp
                             alias: Home page - Indoor temperature
@@ -7130,7 +7128,6 @@ actions:
                               - if:
                                   - '{{ page_constructor is defined and page_constructor }}'
                                 then:
-                                  - *delay_default
                                   - action: 'esphome.{{ nspanel_name }}_components_visibility'
                                     data:
                                       page: home
@@ -7142,6 +7139,7 @@ actions:
                                           else false
                                         }}
                                     continue_on_error: true
+                                  - *delay_default
                               - condition:
                                   - '{{ home_indoor_temp_visible is defined and home_indoor_temp_visible }}'
                                   - '{{ not embedded_indoor_temperature }}'
@@ -7170,7 +7168,6 @@ actions:
                                   indoor_temp_trimmed: >
                                     {{ indoor_temp | regex_replace('\s+', ' ') | trim }}
                               - condition: '{{ indoor_temp_trimmed != "" }}'
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_component_text'
                                 data:
                                   page: home
@@ -7186,7 +7183,6 @@ actions:
                                     custom_button_entity_id_is_valid: '{{ repeat.item.entity is defined and repeat.item.entity is string and repeat.item.entity.split(".") | count == 2 }}'
                                     page_constructor: '{{ page_constructor is defined and page_constructor }}'
                                 - condition: '{{ custom_button_entity_id_is_valid or page_constructor }}'
-                                - *delay_default
                                 - if: '{{ custom_button_entity_id_is_valid }}'
                                   then:
                                     - variables:
@@ -7227,6 +7223,8 @@ actions:
                                         icon_color: '{{ [0, 0, 0] }}'
                                         visible: false
                                       continue_on_error: true
+                                - *delay_default
+
 
                           ###### Climate chip ######
                           - &update_home_page_climate_chip
@@ -7256,7 +7254,6 @@ actions:
                                         )
                                       )
                                     }}
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_icon'
                                 data:
                                   page: chips
@@ -7270,6 +7267,7 @@ actions:
                                     }}
                                   visible: true
                                 continue_on_error: true
+                              - *delay_default
 
                           ###### Status / Chips bar ######
                           - &update_chips_bar
@@ -7285,7 +7283,6 @@ actions:
                                 - &update_individual_chip
                                   if: '{{ repeat.item.entity is defined and repeat.item.entity is string and repeat.item.entity.split(".") | count == 2 }}'
                                   then:
-                                    - *delay_default
                                     - variables:
                                         icon_color_rgb_valid: >
                                           {{
@@ -7337,7 +7334,6 @@ actions:
                                             )
                                           }}
                                     - condition: '{{ entity.icon is defined and entity.icon is string and entity.icon | length > 0 }}'
-                                    - *delay_default
                                     - action: 'esphome.{{ nspanel_name }}_icon'
                                       data:
                                         page: chips
@@ -7355,6 +7351,7 @@ actions:
                                           {% endif %}
                                         visible: '{{ chip_visible }}'
                                       continue_on_error: true
+                                    - *delay_default
 
                           - repeat:
                               for_each: >
@@ -7372,7 +7369,6 @@ actions:
                                     - '{{ repeat.item.entity is string }}'
                                     - '{{ repeat.item.entity.split(".") | count == 2 }}'
                                   then:
-                                    - *delay_default
                                     - variables:
                                         entity_id: '{{ repeat.item.entity }}'
                                         default_color: *default_home_value_color
@@ -7407,7 +7403,6 @@ actions:
                                         - if: '{{ hide_if_zero is defined and hide_if_zero and value_is_zero }}'
                                           then:
                                             # Numeric state rounds to zero: hide both value and icon
-                                            - *delay_default
                                             - action: 'esphome.{{ nspanel_name }}_components_visibility'
                                               data:
                                                 page: '{{ repeat.item.page }}'
@@ -7419,14 +7414,13 @@ actions:
                                           else:
                                             - if: '{{ entity.icon | length > 0 }}'
                                               then:
-                                                - *delay_default
                                                 - action: 'esphome.{{ nspanel_name }}_component_text'
                                                   data:
                                                     page: '{{ repeat.item.page }}'
                                                     id: '{{ repeat.item.component }}_icon'
                                                     txt: '{{ entity.icon }}'
                                                   continue_on_error: true
-                                            - *delay_default
+                                                - *delay_default
                                             - alias: value_with_unit_and_translations
                                               action: 'esphome.{{ nspanel_name }}_component_text'
                                               data:
@@ -7443,8 +7437,8 @@ actions:
                                                     else "_{_unavailable_}_"
                                                   }}
                                               continue_on_error: true
-                                            # Restore visibility after any displayable state (e.g. zero → non-zero transition)
                                             - *delay_default
+                                            # Restore visibility after any displayable state (e.g. zero → non-zero transition)
                                             - action: 'esphome.{{ nspanel_name }}_components_visibility'
                                               data:
                                                 page: '{{ repeat.item.page }}'
@@ -7455,15 +7449,14 @@ actions:
                                               continue_on_error: true
                                       else:
                                         # No value (unavailable/unknown): show localized marker and keep icon visible
-                                        - *delay_default
                                         - action: 'esphome.{{ nspanel_name }}_component_text'
                                           data:
                                             page: '{{ repeat.item.page }}'
                                             id: '{{ repeat.item.component }}'
                                             txt: '_{_unavailable_}_'
                                           continue_on_error: true
-                                        # Ensure both value and icon are visible (recovery from hide-if-zero)
                                         - *delay_default
+                                        # Ensure both value and icon are visible (recovery from hide-if-zero)
                                         - action: 'esphome.{{ nspanel_name }}_components_visibility'
                                           data:
                                             page: '{{ repeat.item.page }}'
@@ -7472,8 +7465,8 @@ actions:
                                               - '{{ repeat.item.component }}_icon'
                                             visible: true
                                           continue_on_error: true
+                                    - *delay_default
 
-                      ## BUTTON PAGES 01 - 04 ##
                       - alias: Button pages
                         conditions: '{{ nspanel_event.page in pages.buttonpages }}'
                         sequence: &refresh_page_buttonpage
@@ -7481,54 +7474,26 @@ actions:
                             variables:
                               event_page: '{{ nspanel_event.page if nspanel_event is defined and nspanel_event.page is defined else pages.current }}'
                               button_pages_icon_size: !input button_pages_icon_size
-                              ##### BUTTON Page Labels #####
-                              confirm_list: >
-                                {{
-                                  buttons_pages.buttons
-                                  | selectattr("page", "defined")
-                                  | selectattr("page", "eq", event_page)
-                                  | sort(attribute="component")
-                                  | map(attribute="confirm")
-                                  | list
-                                }}
-                              confirm_value: >
-                                {% set ns = namespace(decimal_value = 0, index = 0) %}
-                                {% for confirm_item in confirm_list %}
-                                    {% if (confirm_item) %}
-                                        {% set ns.decimal_value = ns.decimal_value + (2 ** ns.index) %}
-                                    {% endif %}
-                                    {% set ns.index = ns.index + 1 %}
-                                {% endfor %}
-                                {{ ns.decimal_value }}
                           - if: '{{ event_page in pages.buttonpages }}'
                             then:
-                              ##### Button page Label #####
-                              - if: >
+                              - alias: Button pages label
+                                if: >
                                   {{
                                     buttons_pages.labels[event_page] != None and
                                     buttons_pages.labels[event_page] != [] and
                                     (buttons_pages.labels[event_page] | string) | length > 0
                                   }}
                                 then:
-                                  - *delay_default
                                   - action: 'esphome.{{ nspanel_name }}_component_text'
                                     data:
                                       page: ""
                                       id: page_label
                                       txt: '{{ buttons_pages.labels[event_page] | string }}'
                                     continue_on_error: true
+                                  - *delay_default
 
-                              ###### Confirm buttons ######
-                              - *delay_default
-                              - action: 'esphome.{{ nspanel_name }}_component_val'
-                                data:
-                                  page: ""
-                                  id: confirm
-                                  val: '{{ confirm_value }}'
-                                continue_on_error: true
-
-                              ##### NSPanel build Button page #####
-                              - repeat:
+                              - alias: Buttons page - Populate buttons
+                                repeat:
                                   for_each: >
                                     {{
                                       buttons_pages.buttons
@@ -7649,7 +7614,35 @@ actions:
                                           continue_on_error: true
                                     - *delay_default
 
-                      ## PAGE LIGHT ##
+                              - alias: Page buttons - Confirm value
+                                sequence:
+                                  - variables:
+                                      confirm_list: >
+                                        {{
+                                          buttons_pages.buttons
+                                          | selectattr("page", "defined")
+                                          | selectattr("page", "eq", event_page)
+                                          | sort(attribute="component")
+                                          | map(attribute="confirm")
+                                          | list
+                                        }}
+                                      confirm_value: >
+                                        {% set ns = namespace(decimal_value = 0, index = 0) %}
+                                        {% for confirm_item in confirm_list %}
+                                            {% if (confirm_item) %}
+                                                {% set ns.decimal_value = ns.decimal_value + (2 ** ns.index) %}
+                                            {% endif %}
+                                            {% set ns.index = ns.index + 1 %}
+                                        {% endfor %}
+                                        {{ ns.decimal_value }}
+                                  - action: 'esphome.{{ nspanel_name }}_component_val'
+                                    data:
+                                      page: ""
+                                      id: confirm
+                                      val: '{{ confirm_value }}'
+                                    continue_on_error: true
+                                  - *delay_default
+
                       - alias: Light settings page
                         conditions: '{{ nspanel_event.page == pages.light }}'
                         sequence: &refresh_page_light
@@ -7679,25 +7672,25 @@ actions:
                                   - '{{ entity.name is string }}'
                                   - '{{ entity.name | length > 0 }}'
                                 then:
-                                  - *delay_default
                                   - action: 'esphome.{{ nspanel_name }}_component_text'
                                     data:
                                       page: ""
                                       id: page_label
                                       txt: '{{ entity.name }}'
                                     continue_on_error: true
+                                  - *delay_default
                               - if:
                                   - '{{ entity.icon is defined }}'
                                   - '{{ entity.icon is string }}'
                                   - '{{ entity.icon | length > 0 }}'
                                 then:
-                                  - *delay_default
                                   - action: 'esphome.{{ nspanel_name }}_component_text'
                                     data:
                                       page: ""
                                       id: icon_state
                                       txt: '{{ entity.icon }}'
                                     continue_on_error: true
+                                  - *delay_default
                           - &variables_light_modes
                             alias: variables_light_modes
                             variables:
@@ -7725,7 +7718,8 @@ actions:
                                     enum.ColorMode.XY in supported_color_modes or
                                     enum.ColorMode.RGB in supported_color_modes or
                                     enum.ColorMode.RGBW in supported_color_modes or
-                                    enum.ColorMode.RGBWW in supported_color_modes or                                    "hs" in supported_color_modes or
+                                    enum.ColorMode.RGBWW in supported_color_modes or
+                                    "hs" in supported_color_modes or
                                     "xy" in supported_color_modes or
                                     "rgb" in supported_color_modes or
                                     "rgbw" in supported_color_modes or
@@ -7746,7 +7740,6 @@ actions:
                           ##### LIGHT State #####
                           - variables:
                               curr_brightness: '{{ (state_attr(entity_id, "brightness") | int(0) * 100 / 255) | round(0) }}'
-                          - *delay_default
                           - action: 'esphome.{{ nspanel_name }}_component_val'
                             data:
                               page: light
@@ -7767,6 +7760,7 @@ actions:
                               id: light_value_2
                               txt: '{{ curr_brightness }}%'
                             continue_on_error: true
+                          - *delay_default
 
                           ##### LIGHT Check Color_Temp Value is available when yes send some current Values #####
                           - if: '{{ color_mode_color_temp }}'
@@ -7783,7 +7777,6 @@ actions:
                                       else ((min_color_temp_kelvin+max_color_temp_kelvin)/2) | int(4268)
                                     }}
                               - condition: '{{ is_number(curr_color_temp) }}'
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_component_text'
                                 data:
                                   page: light
@@ -7828,11 +7821,11 @@ actions:
                                   ids: ["temp_button", "temp_value_2", "temp_touch"]
                                   visible: true
                                 continue_on_error: true
+                              - *delay_default
 
                           ##### Hide color button when not supported #####
                           - if: '{{ color_mode_color }}'
                             then:
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_components_visibility'
                                 data:
                                   page: light
@@ -7840,7 +7833,6 @@ actions:
                                   visible: true
                                 continue_on_error: true
 
-                      ## PAGE COVER ##
                       - alias: Cover settings page
                         conditions: '{{ nspanel_event.page == pages.cover }}'
                         sequence: &refresh_page_cover
@@ -7863,7 +7855,6 @@ actions:
                           - *variable_entity
                           - *entity_details_title_with_icon
                           ##### Cover Open/close Icons #####
-                          - *delay_default
                           - action: 'esphome.{{ nspanel_name }}_component_text'
                             data:
                               page: cover
@@ -7877,9 +7868,9 @@ actions:
                               id: cover_close
                               txt: '{{ cover_icons.close }}'
                             continue_on_error: true
+                          - *delay_default
 
                           ##### COVER State
-                          - *delay_default
                           - action: 'esphome.{{ nspanel_name }}_component_val'
                             data:
                               page: cover
@@ -7893,6 +7884,7 @@ actions:
                               id: cover_value
                               txt: '{{ (state_attr(entity_id, "current_position") | int ) | round(0) }} %'
                             continue_on_error: true
+                          - *delay_default
 
                           ##### COVER Battery ICON Yes / NO #####
                           - variables:
@@ -7938,23 +7930,22 @@ actions:
                                     {% else %}
                                       battery-outline
                                     {% endif %}
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_component_text'
                                 data:
                                   page: cover
                                   id: battery_value
                                   txt: '{{ battery_level }} %'
                                 continue_on_error: true
-                              ### ICON Battery Font Color ###
                               - *delay_default
+                              ### ICON Battery Font Color ###
                               - action: 'esphome.{{ nspanel_name }}_component_color'
                                 data:
                                   page: cover
                                   id: battery_icon
                                   color: '{{ nextion.color.grey_super_light }}'
                                 continue_on_error: true
-                              ### ICON Battery Font ###
                               - *delay_default
+                              ### ICON Battery Font ###
                               - action: 'esphome.{{ nspanel_name }}_component_text'
                                 data:
                                   page: cover
@@ -7962,7 +7953,6 @@ actions:
                                   txt: '{{ all_icons[battery_icon] }}'
                                 continue_on_error: true
 
-                      ## PAGE FAN ##
                       - alias: Fan settings page
                         conditions: '{{ nspanel_event.page == pages.fan }}'
                         sequence: &refresh_page_fan
@@ -7987,7 +7977,6 @@ actions:
                           - *entity_details_title_with_icon
                           - if: '{{ fan.steps > 0 and fan.supported_features | bitwise_and(2) > 0 }}'  # Oscillate
                             then:
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_component_text'
                                 data:
                                   page: fan
@@ -8008,8 +7997,8 @@ actions:
                                   ids: ["bt_oscillate"]
                                   visible: true
                                 continue_on_error: true
+                              - *delay_default
                           - condition: '{{ fan.steps > 0 and fan.supported_features | bitwise_and(1) > 0 }}'  # Set speed
-                          - *delay_default
                           - action: 'esphome.{{ nspanel_name }}_component_val'
                             data:
                               page: fan
@@ -8050,7 +8039,6 @@ actions:
                               color: [192, 192, 192]
                             continue_on_error: true
 
-                      ## PAGE MEDIA PLAYER ##
                       - alias: Media player settings page
                         conditions: '{{ nspanel_event.page == pages.media_player }}'
                         sequence: &refresh_page_media_player
@@ -8091,7 +8079,6 @@ actions:
                                           if (state_attr(entity_id, "mass_player_type") | default("")) == "group"
                                           else state_attr(entity_id, "supported_features") | int(0)
                                         }}
-                                - *delay_default
                                 - action: 'esphome.{{ nspanel_name }}_page_media_player'
                                   data:
                                     entity: '{{ entity_id }}'
@@ -8144,7 +8131,6 @@ actions:
                                     - '{{ states(currentpage) != pages.media_player }}'  # Don't replace this by pages.current as this have to be evaluated all the time
                                     - '{{ nspanel_event.type != "page_changed" }}'
 
-                      ## PAGE ALARM ##
                       - alias: Alarm settings page
                         conditions: '{{ nspanel_event.page == pages.alarm }}'
                         sequence: &refresh_page_alarm
@@ -8173,7 +8159,6 @@ actions:
                                   alarm:
                                     code_format: '{{ state_attr(entity_id, "code_format") }}'
                                     code_arm_required: '{{ state_attr(entity_id, "code_arm_required") | default(true) }}'
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_page_alarm'
                                 data:
                                   state: '{{ entity_state }}'
@@ -8183,7 +8168,6 @@ actions:
                                   entity: '{{ entity_id }}'
                                 continue_on_error: true
 
-                      ## PAGE CLIMATE ##
                       - alias: Climate page
                         conditions:
                           - '{{ nspanel_event.page == pages.climate }}'
@@ -8219,21 +8203,21 @@ actions:
                               - '{{ nspanel_event.page == pages.climate }}'
                               - '{{ climate_entity is defined }}'
                             then:
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_entity_details_show'
                                 data:
                                   entity: '{{ climate_entity }}'
                                   back_page: home
                                 continue_on_error: true
+                              - *delay_default
 
                           - condition: '{{ settings_entity_domain == "climate" }}'
-                          - *delay_default
                           - action: 'esphome.{{ nspanel_name }}_component_text'
                             data:
                               page: ""
                               id: page_label
                               txt: '{{ friendly_name }}'
                             continue_on_error: true
+                          - *delay_default
 
                           ##### Values #####
                           - &variables-climate_page
@@ -8276,7 +8260,6 @@ actions:
                                 - *display_value
                                 - if: '{{ repeat.item.label_color_rgb != [200, 204, 200] }}'
                                   then:
-                                    - *delay_default
                                     - action: 'esphome.{{ nspanel_name }}_component_color'
                                       data:
                                         page: '{{ repeat.item.page }}'
@@ -8290,6 +8273,7 @@ actions:
                                         id: '{{ repeat.item.component }}_icon'
                                         color: '{{ repeat.item.label_color_rgb }}'
                                       continue_on_error: true
+                                    - *delay_default
 
                           ##### Slider & climate values #####
                           - &climate-update_slider
@@ -8336,7 +8320,6 @@ actions:
                                     {% elif "idle" in climate_action %}{{ all_icons.thermometer }}
                                     {% else %}{{ all_icons.blank }}
                                     {% endif %}
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_page_climate'
                                 data:
                                   current_temp: '{{ current_temp }}'
@@ -8351,6 +8334,7 @@ actions:
                                   embedded_climate: '{{ climate_entity == thermostat_embedded }}'
                                   entity: '{{ "embedded_climate" if climate_entity == thermostat_embedded else climate_entity }}'
                                 continue_on_error: true
+                              - *delay_default
 
                           ##### Climate buttons #####
                           - &climate-update_buttons
@@ -8360,9 +8344,7 @@ actions:
                                   for_each: '{{ page_climate.buttons.hvac_mode }}'
                                   sequence:
                                     - condition: '{{ repeat.item.mode in hvac_modes }}'
-                                    - *delay_default
                                     ### ICON Font Color ###
-                                    - *delay_default
                                     - action: 'esphome.{{ nspanel_name }}_component_color'
                                       data:
                                         page: climate
@@ -8374,22 +8356,23 @@ actions:
                                             else nextion.color.disabled
                                           }}
                                       continue_on_error: true
-                                    ### ICON Font ###
                                     - *delay_default
+                                    ### ICON Font ###
                                     - action: 'esphome.{{ nspanel_name }}_component_text'
                                       data:
                                         page: climate
                                         id: '{{ repeat.item.component }}'
                                         txt: '{{ all_icons[repeat.item.icon] }}'
                                       continue_on_error: true
-                                    ### Enable button click ###
                                     - *delay_default
+                                    ### Enable button click ###
                                     - action: 'esphome.{{ nspanel_name }}_components_visibility'
                                       data:
                                         page: climate
                                         ids: '{{ [ repeat.item.component ] }}'
                                         visible: true
                                       continue_on_error: true
+                                    - *delay_default
 
                           - &climate_custom_buttons
                             alias: Climate custom buttons
@@ -8428,31 +8411,30 @@ actions:
                                           icon_color: '{{ repeat.item.icon_color_rgb }}'
                                     - *variable_entity
                                     ### ICON Font Color ###
-                                    - *delay_default
                                     - action: 'esphome.{{ nspanel_name }}_component_color'
                                       data:
                                         page: climate
                                         id: '{{ repeat.item.component }}'
                                         color: '{{ entity.icon_color }}'
                                       continue_on_error: true
-                                    ### ICON Font ###
                                     - *delay_default
+                                    ### ICON Font ###
                                     - action: 'esphome.{{ nspanel_name }}_component_text'
                                       data:
                                         page: climate
                                         id: '{{ repeat.item.component }}'
                                         txt: '{{ entity.icon }}'
                                       continue_on_error: true
-                                    ### Enable button click ###
                                     - *delay_default
+                                    ### Enable button click ###
                                     - action: 'esphome.{{ nspanel_name }}_components_visibility'
                                       data:
                                         page: climate
                                         ids: '{{ [ repeat.item.component ] }}'
                                         visible: true
                                       continue_on_error: true
+                                    - *delay_default
 
-                      ## PAGE BUTTON ##
                       - alias: Button page
                         conditions:
                           - '{{ nspanel_event.page == pages.button }}'
@@ -8468,14 +8450,13 @@ actions:
                           - *entity_details_title_with_icon
                           - if: '{{ entity.icon is defined and entity.icon is string and entity.icon | length > 0 }}'
                             then:
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_component_text'
                                 data:
                                   page: ""
                                   id: icon
                                   txt: '{{ entity.icon }}'
                                 continue_on_error: true
-                          - *delay_default
+                              - *delay_default
                           - action: 'esphome.{{ nspanel_name }}_component_val'
                             data:
                               page: ""
@@ -8488,7 +8469,6 @@ actions:
                               cmd: 'render.en=1'
                             continue_on_error: true
 
-                      ## PAGE SWITCH ##
                       - alias: Switch page
                         conditions:
                           - '{{ nspanel_event.page == pages.switch }}'
@@ -8524,7 +8504,6 @@ actions:
                               cmd: 'render.en=1'
                             continue_on_error: true
 
-                      ## PAGE WATER HEATER ##
                       - alias: Water Heater page
                         conditions:
                           - '{{ nspanel_event.page == pages.water_heater }}'
@@ -8575,21 +8554,21 @@ actions:
                               - '{{ water_heater_entity is string }}'
                               - '{{ water_heater_entity is match "water_heater." }}'
                             then:
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_entity_details_show'
                                 data:
                                   entity: '{{ water_heater_entity }}'
                                   back_page: home
                                 continue_on_error: true
+                              - *delay_default
 
                           - condition: '{{ settings_entity_domain == "water_heater" }}'
-                          - *delay_default
                           - action: 'esphome.{{ nspanel_name }}_component_text'
                             data:
                               page: ""
                               id: page_label
                               txt: '{{ friendly_name }}'
                             continue_on_error: true
+                          - *delay_default
 
                           ##### Values #####
                           - &variables_water_heater_page
@@ -8642,22 +8621,22 @@ actions:
                                       }}
                                 - if: '{{ var_icon != False }}'
                                   then:
-                                    - *delay_default
                                     - action: 'esphome.{{ nspanel_name }}_component_text'
                                       data:
                                         page: '{{ repeat.item.page }}'
                                         id: '{{ repeat.item.component }}_icon'
                                         txt: '{{ var_icon }}'
                                       continue_on_error: true
+                                    - *delay_default
                                 - if: '{{ repeat.item.label_color_rgb != [200, 204, 200] }}'
                                   then:
-                                    - *delay_default
                                     - action: 'esphome.{{ nspanel_name }}_component_color'
                                       data:
                                         page: '{{ repeat.item.page }}'
                                         id: '{{ repeat.item.component }}'
                                         color: '{{ repeat.item.label_color_rgb }}'
                                       continue_on_error: true
+                                    - *delay_default
 
                           ##### Slider & water heater values #####
                           - &water_heater_update_slider
@@ -8716,7 +8695,6 @@ actions:
                                     {{ (((10 * target_temp) - temp_offset) / temp_step) | round(0) | int if is_target_temperature else 0 }}
 
                               ##### Slider configuration #####
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_command'
                                 data:
                                   cmd: 'slider.maxval={{ total_steps }}'
@@ -8749,18 +8727,18 @@ actions:
                                   id: dec_separator
                                   txt: '{{ decimal_separator }}'
                                 continue_on_error: true
+                              - *delay_default
 
                               ##### Current temperature #####
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_component_text'
                                 data:
                                   page: water_heater
                                   id: current_temp
                                   txt: '{{ current_temp_text }}'
                                 continue_on_error: true
+                              - *delay_default
 
                               ##### Target temperature & slider #####
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_components_visibility'
                                 data:
                                   page: water_heater
@@ -8769,7 +8747,6 @@ actions:
                                 continue_on_error: true
                               - if: '{{ is_target_temperature }}'
                                 then:
-                                  - *delay_default
                                   - action: 'esphome.{{ nspanel_name }}_component_text'
                                     data:
                                       page: water_heater
@@ -8790,24 +8767,24 @@ actions:
                                       id: target_icon
                                       txt: '{{ water_heater_icon }}'
                                     continue_on_error: true
+                                  - *delay_default
 
                           ##### Water heater buttons #####
                           - &water_heater_update_buttons
                             alias: water_heater_update_buttons
                             sequence:
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_components_visibility'
                                 data:
                                   page: water_heater
                                   ids: '{{ page_water_heater.buttons.operation_mode | map(attribute="component") | list }}'
                                   visible: false
                                 continue_on_error: true
+                              - *delay_default
                               - repeat:
                                   for_each: '{{ page_water_heater.buttons.operation_mode }}'
                                   sequence:
                                     - condition: '{{ repeat.item.mode in operation_list }}'
                                     ### ICON Font Color ###
-                                    - *delay_default
                                     - action: 'esphome.{{ nspanel_name }}_component_color'
                                       data:
                                         page: water_heater
@@ -8819,25 +8796,25 @@ actions:
                                             else nextion.color.disabled
                                           }}
                                       continue_on_error: true
-                                    ### ICON Font ###
                                     - *delay_default
+                                    ### ICON Font ###
                                     - action: 'esphome.{{ nspanel_name }}_component_text'
                                       data:
                                         page: water_heater
                                         id: '{{ repeat.item.component }}'
                                         txt: '{{ all_icons[repeat.item.icon] }}'
                                       continue_on_error: true
-                                    ### Enable button click ###
                                     - *delay_default
+                                    ### Enable button click ###
                                     - action: 'esphome.{{ nspanel_name }}_components_visibility'
                                       data:
                                         page: water_heater
                                         ids: '{{ [ repeat.item.component ] }}'
                                         visible: true
                                       continue_on_error: true
+                                    - *delay_default
 
-                      ## ENTITY PAGES 01 - 04 ##
-                      - alias: Entity pages
+                      - alias: Entity pages  ## ENTITY PAGES 01 - 04
                         conditions: '{{ nspanel_event.page in pages.entitypages }}'
                         sequence: &refresh_entity_pages
                           - &variables-entity_pages
@@ -8848,13 +8825,13 @@ actions:
                           ##### Entity page - Label #####
                           - if: '{{ entities_pages.labels[event_page] | length > 0 }}'
                             then:
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_component_text'
                                 data:
                                   page: '{{ event_page }}'
                                   id: page_label
                                   txt: '{{ entities_pages.labels[event_page] }}'
                                 continue_on_error: true
+                              - *delay_default
                           ##### Entities #####
                           - repeat:
                               for_each: >
@@ -8868,7 +8845,6 @@ actions:
                                 }}
                               sequence: &update_entity_page_entity
                                 - condition: '{{ repeat.item.entity is string and repeat.item.entity | length > 0 }}'
-                                - *delay_default
                                 - variables:
                                     entity_id: '{{ repeat.item.entity }}'
                                     overlap:
@@ -8890,7 +8866,6 @@ actions:
                                 - alias: Entities pages - Constructor
                                   if: '{{ event_page_constructor is defined and event_page_constructor }}'
                                   then:
-                                    - *delay_default
                                     - action: 'esphome.{{ nspanel_name }}_component_text'
                                       data:
                                         page: '{{ repeat.item.page }}'
@@ -8904,18 +8879,18 @@ actions:
                                         id: '{{ repeat.item.component }}_label'
                                         txt: '{{ entity.name }}'
                                       continue_on_error: true
+                                    - *delay_default
                                 - alias: Entities pages - Values (with icons)
                                   sequence:
-                                    - *delay_default
                                     - action: 'esphome.{{ nspanel_name }}_component_text'
                                       data:
                                         page: '{{ repeat.item.page }}'
                                         id: '{{ repeat.item.component }}'
                                         txt: *value_with_unit_and_translations
                                       continue_on_error: true
+                                    - *delay_default
 
-                      ## PAGE WEATHER (WEATHER01 to WEATHER05) ##
-                      - alias: Weather pages
+                      - alias: Weather pages  ## PAGE WEATHER (WEATHER01 to WEATHER05)
                         conditions: '{{ nspanel_event.page in pages.weatherpages }}'
                         sequence:
                           - variables:
@@ -9382,7 +9357,6 @@ actions:
                                   ##### Display weather PIC when available
                                   - if: '{{ condition not in ["unknown", None] }}'
                                     then:
-                                      - *delay_default
                                       - action: 'esphome.{{ nspanel_name }}_component_val'
                                         data:
                                           page: mem
@@ -9398,6 +9372,7 @@ actions:
                                               else nextion.pic.weather[condition] | int(1)
                                             }}
                                         continue_on_error: true
+                                      - *delay_default
 
                                   ##### Display temperature min/max when available
                                   - variables:
@@ -9407,19 +9382,18 @@ actions:
                                           {{ (temp_max | round(0) ~ weather_temp_units) if is_number(temp_max) and temp_min != temp_max }}
                                   - if: '{{ (is_number(temp_min) or is_number(temp_max)) and temperature_string is string and temperature_string | length > 0 }}'
                                     then:
-                                      - *delay_default
                                       - action: 'esphome.{{ nspanel_name }}_component_text'
                                         data:
                                           page: '{{ page_name }}'
                                           id: 'temperature'  ### Temperature MIN/MAX ###
                                           txt: '{{ temperature_string }}'
                                         continue_on_error: true
+                                      - *delay_default
 
                                   ##### fields 1 to 5 (Parameters) #####
                                   - repeat:
                                       for_each: '{{ (parameters | selectattr("visibility", "eq", true) | list)[:5] }}'
                                       sequence:
-                                        - *delay_default
                                         - action: 'esphome.{{ nspanel_name }}_component_text'
                                           data:
                                             page: '{{ page_name }}'
@@ -9433,8 +9407,8 @@ actions:
                                             id: 'value0{{ repeat.index }}_icon'
                                             txt: '{{ repeat.item.icon }}'
                                           continue_on_error: true
+                                        - *delay_default
                                 else: &forecast_unavailable
-                                  - *delay_default
                                   - action: 'esphome.{{ nspanel_name }}_component_text'
                                     data:
                                       page: '{{ page_name }}'
@@ -9443,8 +9417,7 @@ actions:
                                     continue_on_error: true
                             else: *forecast_unavailable
 
-                      ## PAGE UTILITIES ##
-                      - alias: Utilities page
+                      - alias: Utilities page  ## PAGE UTILITIES
                         conditions: '{{ nspanel_event.page == pages.utilities }}'
                         sequence: &refresh_page_utilities
                           - alias: Utilities page - Title
@@ -9452,21 +9425,21 @@ actions:
                               - variables:
                                   page_icon: '{{ pages_utilities.title.icon.split("mdi:")[1] if pages_utilities.title.icon is string and pages_utilities.title.icon.split("mdi:") | count == 2 }}'
 
-                              - *delay_default
                               - action: 'esphome.{{ nspanel_name }}_component_text'
                                 data:
                                   page: utilities
                                   id: title_icon
                                   txt: '{{ all_icons[page_icon] if page_icon in all_icons else all_icons.gauge }}'
                                 continue_on_error: true
-
                               - *delay_default
+
                               - action: 'esphome.{{ nspanel_name }}_component_text'
                                 data:
                                   page: utilities
                                   id: title
                                   txt: '{{ pages_utilities.title.label }}'
                                 continue_on_error: true
+                              - *delay_default
 
                           - variables:
                               utilities_constructor_init: true
@@ -9504,7 +9477,6 @@ actions:
                                   then:
                                     - variables:
                                         icon_code: '{{ repeat.item.icon.split("mdi:")[1] }}'
-                                    - *delay_default
                                     - action: 'esphome.{{ nspanel_name }}_icon'
                                       data:
                                         page: utilities
@@ -9518,10 +9490,10 @@ actions:
                                           }}
                                         visible: '{{ icon_code in all_icons }}'
                                       continue_on_error: true
+                                    - *delay_default
                                 - alias: Utilities - Label
                                   if: '{{ label_enabled }}'
                                   then:
-                                    - *delay_default
                                     - action: 'esphome.{{ nspanel_name }}_component_text'
                                       data:
                                         page: utilities
@@ -9542,6 +9514,7 @@ actions:
                                         ids: '{{ [repeat.item.name ~ "_label"] }}'
                                         visible: true
                                       continue_on_error: true
+                                    - *delay_default
 
                                 - variables:
                                     line_ref_state: >
@@ -9588,11 +9561,11 @@ actions:
                                         direction: '{{ direction }}'
                                         constructor: '{{ utilities_constructor }}'
                                       continue_on_error: true
+                                    - *delay_default
                                     - if: '{{ utilities_constructor }}'
                                       then:
                                         - if: '{{ value1_enabled }}'
                                           then:
-                                            - *delay_default
                                             - action: 'esphome.{{ nspanel_name }}_component_color'
                                               data:
                                                 page: utilities
@@ -9606,9 +9579,9 @@ actions:
                                                 ids: '{{ [repeat.item.name] }}'
                                                 visible: true
                                               continue_on_error: true
+                                            - *delay_default
                                         - if: '{{ value2_enabled }}'
                                           then:
-                                            - *delay_default
                                             - action: 'esphome.{{ nspanel_name }}_component_color'
                                               data:
                                                 page: utilities
@@ -9622,6 +9595,7 @@ actions:
                                                 ids: '{{ [repeat.item.name ~ "b"] }}'
                                                 visible: true
                                               continue_on_error: true
+                                            - *delay_default
                                 - alias: Utilities - Line
                                   if:
                                     - '{{ icon_enabled or value1_enabled or value2_enabled or label_enabled }}'
@@ -9630,7 +9604,6 @@ actions:
                                   then:
                                     - variables:
                                         rgb565: '{{ int(((repeat.item.color[0] //(2**3)) *(2**11))+((repeat.item.color[1] //(2**2)) *(2**5))+(repeat.item.color[2] //(2**3))) }}'
-                                    - *delay_default
                                     - action: 'esphome.{{ nspanel_name }}_command'
                                       data:
                                         cmd: '{{ repeat.item.name }}_line.bco={{ rgb565 }}'
@@ -9640,22 +9613,22 @@ actions:
                                       data:
                                         cmd: '{{ repeat.item.name }}_line.bco1={{ rgb565 }}'
                                       continue_on_error: true
+                                    - *delay_default
                                     - if: '{{ pages_utilities.cursor.width != 255 }}'
                                       then:
-                                        - *delay_default
                                         - action: 'esphome.{{ nspanel_name }}_command'
                                           data:
                                             cmd: '{{ repeat.item.name }}_line.wid={{ pages_utilities.cursor.width }}'
                                           continue_on_error: true
-                                    - *delay_default
+                                        - *delay_default
                                     - action: 'esphome.{{ nspanel_name }}_components_visibility'
                                       data:
                                         page: utilities
                                         ids: '{{ [repeat.item.name ~ "_line"] }}'
                                         visible: true
                                       continue_on_error: true
+                                    - *delay_default
 
-              ##### Button click #####
               - alias: Button click
                 conditions:
                   - '{{ nspanel_event.type == "button_click" }}'
@@ -9712,7 +9685,6 @@ actions:
                                               back_page: '{{ pages.home }}'
                                           - &entity_details_show
                                             sequence:
-                                              - *delay_default
                                               - action: 'esphome.{{ nspanel_name }}_entity_details_show'
                                                 data:
                                                   entity: '{{ "embedded_climate" if entity_id == thermostat_embedded else entity_id }}'
@@ -9722,7 +9694,6 @@ actions:
                                               - condition: '{{ entity.name is defined }}'
                                               - condition: '{{ entity.name is string }}'
                                               - condition: '{{ entity.name | length > 0 }}'
-                                              - *delay_default
                                               - action: 'esphome.{{ nspanel_name }}_component_text'
                                                 data:
                                                   page: ""
@@ -10226,7 +10197,6 @@ actions:
                       # yamllint enable rule:line-length
                       # yamllint enable rule:comments-indentation
 
-              ##### Other events #####
               - alias: Other events
                 conditions:
                   - '{{ nspanel_event.type == "generic" }}'
@@ -10702,7 +10672,6 @@ actions:
           - condition: trigger
             id: wake_up_sensors
         sequence:
-          - *delay_default
           - action: 'esphome.{{ nspanel_name }}_wake_up'
             data:
               reset_timer: true

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -6,7 +6,7 @@
 ##################################################################################################
 ---
 blueprint:
-  name: NSPanel Easy Configuration (v2026.4.21)
+  name: NSPanel Easy Configuration (v9999.99.9)
   author: Edward Firmo (https://github.com/edwardtfn)
   description: >
     # NSPanel Easy Configuration via Blueprint
@@ -3900,28 +3900,33 @@ blueprint:
                 - label: 48px
                   value: '10'
         delay:
-          name: Command Delay to Prevent Overload
+          name: Command Delay
           description: >
-            Adjusts the delay between sequential commands to the Nextion display, preventing overload and synchronization issues.
-            While increasing delay enhances stability, it may slow down page rendering.
-          default: 25
+            Small delay between sequential Home Assistant action calls to the panel.
+            Helps ensure ordering when many calls are dispatched in quick succession.
+            The Nextion-side command pacer handles display buffer protection, so this value can usually stay low.
+            Increase only if you observe missing or out-of-order commands on busy networks.
+          default: 10
           selector:
             number:
               min: 0
-              max: 250
+              max: 25
               step: 1
               unit_of_measurement: milliseconds
               mode: box
         delay_boot:
-          name: Command Delay to Prevent Overload during panel's boot
+          name: Command Delay During Boot
           description: >
-            Adjusts the delay between sequential commands to the Nextion display, preventing overload and synchronization issues.
-            While increasing delay enhances stability, it may slow down the boot sequence.
-          default: 375
+            Delay between sequential Home Assistant service calls to the panel during the boot sequence.
+            Boot involves a large burst of commands (settings, icons, component initialization),
+            so a slightly higher value than the runtime delay is needed to ensure reliable boot.
+            Values below ~25 ms have been observed to cause Nextion buffer overflows during boot.
+            Values above 100 ms are rarely needed.
+          default: 50
           selector:
             number:
               min: 0
-              max: 2500
+              max: 250
               step: 1
               unit_of_measurement: milliseconds
               mode: box
@@ -4058,7 +4063,7 @@ trigger_variables:
 
 variables:
   # Version will be following release version defined automatically when merging to main
-  blueprint_version: 2026.4.21
+  blueprint_version: 9999.99.9
   pages:
     current: '{{ states(currentpage) }}'
     alarm: "alarm"
@@ -6161,6 +6166,7 @@ actions:
                     trigger.event.data is defined
                   else none
                 }}
+          - condition: '{{ nspanel_event is not none }}'
           - choose:
               ##### BOOT NSPANEL - boot init #####
               - alias: Boot init
@@ -7028,6 +7034,7 @@ actions:
               - alias: Page changed
                 conditions:
                   - '{{ nspanel_event.type == "page_changed"}}'
+                  - '{{ nspanel_event.page is defined }}'
                 sequence:
                   - choose:
                       ## PAGE HOME ##
@@ -8179,8 +8186,6 @@ actions:
                       ## PAGE CLIMATE ##
                       - alias: Climate page
                         conditions:
-                          - '{{ nspanel_event is defined }}'
-                          - '{{ nspanel_event.page is defined }}'
                           - '{{ nspanel_event.page == pages.climate }}'
                         sequence: &refresh_page_climate
                           - *get_entity_id_from_event_or_trigger
@@ -8450,8 +8455,6 @@ actions:
                       ## PAGE BUTTON ##
                       - alias: Button page
                         conditions:
-                          - '{{ nspanel_event is defined }}'
-                          - '{{ nspanel_event.page is defined }}'
                           - '{{ nspanel_event.page == pages.button }}'
                         sequence: &refresh_page_button
                           - *get_entity_id_from_event_or_trigger
@@ -8488,8 +8491,6 @@ actions:
                       ## PAGE SWITCH ##
                       - alias: Switch page
                         conditions:
-                          - '{{ nspanel_event is defined }}'
-                          - '{{ nspanel_event.page is defined }}'
                           - '{{ nspanel_event.page == pages.switch }}'
                         sequence: &refresh_page_switch
                           - *get_entity_id_from_event_or_trigger
@@ -8526,8 +8527,6 @@ actions:
                       ## PAGE WATER HEATER ##
                       - alias: Water Heater page
                         conditions:
-                          - '{{ nspanel_event is defined }}'
-                          - '{{ nspanel_event.page is defined }}'
                           - '{{ nspanel_event.page == pages.water_heater }}'
                         sequence: &refresh_page_water_heater
                           - &variables_water_heater_entity
@@ -10638,7 +10637,6 @@ actions:
                       )
                   ) in enum.states.on
                 }}
-          - *delay_default
           - action: 'esphome.{{ nspanel_name }}_component_val'
             data:
               page: mem
@@ -10650,13 +10648,14 @@ actions:
                 }}
               val: '{{ 1 if button_state else 0 }}'
             continue_on_error: true
+          # Re-evaluate the entity state after a short settle window;
+          # if it changed meanwhile, update the Nextion indicator again.
           - delay:
               milliseconds: 250
           - variables:
               button_state_new: *button_state_var
           - if: '{{ button_state_new != button_state }}'
             then:
-              - *delay_default
               - action: 'esphome.{{ nspanel_name }}_component_val'
                 data:
                   page: mem


### PR DESCRIPTION
## Performance improvements

Performance tuning of the Nextion command pacing values, informed by stress testing against recent ESPHome behavior.

### Background

A recent ESPHome fix (esphome/esphome#15664) made the Nextion `command_spacing` pacer actually throttle command sends for the first time. Until that fix, the configured value was effectively a no-op — the pacer existed but did not enforce spacing. This means users were running with zero effective pacing for months without widespread buffer overflow issues, and then suddenly experienced slower rendering once the fix landed and the previous 3 ms default started enforcing real delays.

This release re-tunes all three pacing values now that the pacer works as designed.

### Changes and rationale

- **Nextion command spacing: 3 ms → 1 ms**
  Stress testing at 921600 baud compared 3 ms, 1 ms, and no pacer under continuous page changes every second for 60+ minutes. No pacer produced ~11 buffer overflows per hour; 1 ms produced zero. At 3 ms, steady-state rendering was measurably slower than at 1 ms without any additional safety benefit under tested conditions. 1 ms preserves the protection the pacer provides while eliminating the rendering latency users were noticing after updating ESPHome.

- **Blueprint command delay: default 25 ms → 10 ms, maximum 250 ms → 25 ms**
  This delay exists between sequential HA service calls to the panel. Its original purpose was partly buffer protection (now handled by the Nextion-side pacer) and partly ensuring call ordering. Typical LAN round-trip to an ESPHome device is 2-5 ms, so 10 ms provides ~2x headroom for ordering without overprovisioning. The maximum was lowered because values above ~25 ms do not address any problem this setting can solve — if a user needed more, their underlying issue (network, HA performance) is elsewhere.

- **Blueprint boot delay: default 250 ms → 50 ms, maximum 1000 ms → 250 ms**
  Boot involves a larger command burst than runtime (settings, icons, component initialization), so it uses a higher delay than the runtime value. Testing showed 10 ms was too tight for boot (caused buffer overflows), 250 ms was unnecessarily long, and 50 ms is comfortably safe. The maximum was lowered to 250 ms (the previous default) since that value is known to work and going higher only extends boot time without benefit.

### Upgrade notes

If you previously set either blueprint delay above the new maximum, your value may be clamped on upgrade. The reduced values should be sufficient thanks to the Nextion-side pacer.

If you observe missing commands or display glitches on busy networks after upgrading, raise the runtime delay toward its new maximum of 25 ms.

If you observe Nextion buffer overflows in the logs, raise `command_spacing` in your customization YAML (the 1 ms default can be overridden per-panel):
```yaml
display:
  - id: !extend disp1
    command_spacing: 2ms  # Default is now 1ms
```

## Other changes/fixes

- When fallback baud rate is in use, do not change it for TFT upload (#131)
- Display Light add-on dimming below the configured dim-down level (#141)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TFT upload reliability with dynamic baud rate fallback and clearer upload-rate logging.

* **Improvements**
  * Enhanced button event logging for clearer multi-click detection and dispatch visibility.
  * Optimized display command timing for improved responsiveness.

* **Configuration Updates**
  * Blueprint bumped to v9999.99.9 with reduced command-delay defaults, added validation guards, and reordered initialization/delay sequencing.

* **New Features**
  * Display light gamma correction disabled for monochrome output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->