### PR TITLE
fix: Restore home custom button detail-pages

### DIFF
--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -10211,7 +10211,7 @@ actions:
                                 entity_domain in domains_functionality.detailed_only or
                                 (entity_domain == "cover" and supported_features | bitwise_and(4) > 0) or
                                 (entity_domain == "fan" and (supported_features | bitwise_and(1) > 0 or supported_features | bitwise_and(2) > 0)) or
-                                (entity_domain == "light" and (color_mode_brightness or color_mode_color or color_mode_temp))
+                                (entity_domain == "light" and (color_mode_brightness or color_mode_color or color_mode_temp)) or
                                 (entity_domain == "timer")
                               }}
                             then:


### PR DESCRIPTION
Home custom buttons with detail-capable entities could fail to open their detail page.

The guard for the detail-page path concatenated the light capability check and the timer check without an operator. Jinja treats adjacent parenthesized expressions as a call expression, so the boolean result of the light check could be called as a function and raise TypeError.

Add the missing OR to restore the intended capability chain.

Verified with:

- yamllint -c ./.rules/yamllint.yml nspanel_easy_blueprint.yaml
- focused Jinja check for light and timer cases
- manual test with home custom buttons on a local HA/NSPanel setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected custom button handling logic for light and timer domain automation. Button clicks now properly evaluate both light and timer alternatives as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->