### PR TITLE
improve: Chips now update instantly, without running an automation

### DIFF
--- a/components/nspanel_easy/__init__.py
+++ b/components/nspanel_easy/__init__.py
@@ -16,6 +16,7 @@ Supported configuration keys
 
 from esphome import automation
 from esphome import pins
+from esphome.components import nextion
 from esphome.components.esp32 import add_idf_sdkconfig_option
 from esphome.const import (CONF_ID, CONF_TRIGGER_ID)
 from esphome.core import CORE, coroutine_with_priority
@@ -23,13 +24,13 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 import logging
 
-
 CODEOWNERS = ["@edwardtfn"]
 
 _LOGGER = logging.getLogger(__name__)
 
 nspanel_easy_ns = cg.esphome_ns.namespace('nspanel_easy')
 
+CONF_NEXTION_ID = "nextion_id"
 CONF_ON_DUMP_CONFIG = "on_dump_config"
 CONF_ON_SETUP = "on_setup"
 PSRAM_CLK_PIN = "psram_clk_pin"
@@ -42,6 +43,7 @@ DumpConfigTrigger = nspanel_easy_ns.class_("DumpConfigTrigger", automation.Trigg
 
 CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_ID, default="nspanel_easy_component"): cv.declare_id(NSPanelEasyComponent),
+    cv.Required(CONF_NEXTION_ID): cv.use_id(nextion.Nextion),
     cv.Optional(CONF_ON_SETUP): automation.validate_automation(
         {
             cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(SetupTrigger),
@@ -85,6 +87,9 @@ async def to_code(config):
     for conf in config.get(CONF_ON_DUMP_CONFIG, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
+
+    disp = await cg.get_variable(config[CONF_NEXTION_ID])
+    cg.add(cg.RawStatement(f"esphome::nspanel_easy::nextion_display = {disp};"))
 
     # Arduino framework deprecation warning
     if CORE.using_arduino:

--- a/components/nspanel_easy/api_subscriptions.cpp
+++ b/components/nspanel_easy/api_subscriptions.cpp
@@ -403,6 +403,23 @@ static void sub_push_release() {
 }
 
 bool sub_push_end(uint16_t count) {
+  // A push containing no bindings never opens, because sub_push_binding() is
+  // what starts one. The blueprint still sends the end marker when every
+  // component has been unconfigured, so treat that as an explicit empty set --
+  // otherwise the persisted bindings survive and the panel keeps subscribing to
+  // entities the user has removed.
+  if (!sub_pushing && count == 0) {
+    sub_staged = 0;
+    if (!sub_staged_differs()) {
+      ESP_LOGD(TAG, "Bindings unchanged");
+      sub_unverified = 0;
+      return false;
+    }
+    ESP_LOGI(TAG, "All bindings cleared");
+    sub_persist(true);
+    return true;
+  }  // if empty push
+
   if (!sub_pushing) {
     ESP_LOGW(TAG, "End marker received with no push in progress");
     return false;

--- a/components/nspanel_easy/api_subscriptions.cpp
+++ b/components/nspanel_easy/api_subscriptions.cpp
@@ -1,0 +1,479 @@
+// api_subscriptions.cpp
+
+#ifdef NSPANEL_EASY_SUBSCRIBE
+
+#include "api_subscriptions.h"
+
+#include <esp_heap_caps.h>
+
+#include "esphome/components/api/api_server.h"
+#include "esphome/core/application.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include "esphome/core/preferences.h"
+
+#ifdef NSPANEL_EASY_CHIPS
+#include "chips.h"
+#endif  // NSPANEL_EASY_CHIPS
+
+namespace esphome::nspanel_easy {
+
+static const char *const TAG = "nspanel.api.sub";
+
+esphome::nextion::Nextion *nextion_display = nullptr;
+
+SubBinding *sub_bindings = nullptr;
+SubRuntime *sub_runtime = nullptr;
+SubRenderFn *sub_renderers = nullptr;
+uint16_t sub_count = 0;
+
+/// @brief Header persisted alongside the binding chunks.
+struct SubHeader {
+  uint8_t version;     ///< SUB_FORMAT_VERSION at the time of writing
+  uint16_t count;      ///< Number of persisted bindings
+  uint8_t unverified;  ///< Consecutive commits that never received an end marker
+};
+
+/// @brief Staging buffer, allocated for the duration of a push only.
+static SubBinding *sub_staging = nullptr;
+
+/// @brief Bindings received in the push currently in progress.
+static uint16_t sub_staged = 0;
+
+/// @brief Whether a push is currently in progress.
+static bool sub_pushing = false;
+
+/// @brief Consecutive commits that never received an end marker.
+static uint8_t sub_unverified = 0;
+
+/**
+ * @brief Allocate, preferring PSRAM and falling back to internal DRAM.
+ *
+ * Not every NSPanel carries PSRAM, so the fallback is mandatory rather than a
+ * convenience. Allocations here are made once and never resized, which is what
+ * lets the API hold raw pointers into the binding array.
+ *
+ * @param bytes Size to allocate.
+ * @return Zeroed allocation, or nullptr on failure.
+ */
+static void *sub_alloc(size_t bytes) {
+  void *ptr = heap_caps_calloc(1, bytes, MALLOC_CAP_SPIRAM);
+  if (ptr == nullptr) {
+    ptr = heap_caps_calloc(1, bytes, MALLOC_CAP_INTERNAL);
+  }
+  return ptr;
+}
+
+/**
+ * @brief Preference handle for the persisted header.
+ *
+ * @return Preference object for SubHeader.
+ */
+static ESPPreferenceObject sub_header_pref() {
+  return global_preferences->make_preference<SubHeader>(fnv1_hash("nspanel_easy_sub_header"));
+}
+
+/**
+ * @brief Preference handle for one binding chunk.
+ *
+ * Chunking keeps the compare-before-write copy in ESP32Preferences::is_changed()
+ * small: one chunk is under 2 KB, where a single blob would be roughly 14 KB.
+ *
+ * @param chunk Chunk index.
+ * @return Preference object for SubChunk.
+ */
+static ESPPreferenceObject sub_chunk_pref(uint16_t chunk) {
+  return global_preferences->make_preference<SubChunk>(fnv1_hash("nspanel_easy_sub_chunk") + chunk);
+}
+
+/**
+ * @brief Copy a string into a fixed buffer, always null-terminating.
+ *
+ * @param dest Destination buffer.
+ * @param size Size of the destination buffer.
+ * @param src Source string, may be nullptr.
+ */
+static void sub_copy(char *dest, size_t size, const char *src) {
+  if (src == nullptr) {
+    dest[0] = '\0';
+    return;
+  }
+  strncpy(dest, src, size - 1);
+  dest[size - 1] = '\0';
+}
+
+/**
+ * @brief Test whether two bindings would produce the same subscription.
+ *
+ * Only the entity and its target participate. device_class, inverted and
+ * appearance are applied live during a push, so a change to any of them must
+ * never trigger a restart.
+ *
+ * @param a First binding.
+ * @param b Second binding.
+ * @return true when both would subscribe identically.
+ */
+static bool sub_binding_equal(const SubBinding &a, const SubBinding &b) {
+  return strcmp(a.entity, b.entity) == 0 && strcmp(a.page, b.page) == 0 && strcmp(a.component, b.component) == 0;
+}
+
+/**
+ * @brief Recompute and render one binding from its stored state.
+ *
+ * Classification happens here so that renderers never interpret a raw state.
+ *
+ * @param idx Binding index.
+ */
+static void sub_apply(uint16_t idx) {
+  const SubBinding &binding = sub_bindings[idx];
+  SubRuntime &rt = sub_runtime[idx];
+  const SubDomain domain = static_cast<SubDomain>(binding.domain);
+
+  // Climate prefers hvac_action over the hvac mode whenever the attribute holds
+  // a usable value, matching the blueprint's precedence.
+  const char *effective = rt.state;
+  if (domain == SUB_DOMAIN_CLIMATE && rt.action[0] != '\0' && !sub_state_in(rt.action, SUB_UNUSABLE_STATES)) {
+    effective = rt.action;
+  }
+
+  rt.last_state = evaluate_sub_state(domain, effective);
+  const bool visible = sub_visible(rt.last_state, binding.inverted);
+
+  ESP_LOGV(TAG, "%s.%s: '%s' => vis=%s", binding.page, binding.component, effective, YESNO(visible));
+
+  if (sub_renderers[idx] != nullptr) {
+    sub_renderers[idx](binding, rt, effective, visible);
+  }
+}
+
+SubRenderFn sub_resolve_renderer(const char *page) {
+  struct PageEntry {
+    const char *page;
+    SubRenderFn render;
+  };
+  static constexpr PageEntry PAGES[] = {
+#ifdef NSPANEL_EASY_CHIPS
+      {"chips", &chip_sub_render},
+#endif  // NSPANEL_EASY_CHIPS
+  };
+  for (const PageEntry &entry : PAGES) {
+    if (strcmp(page, entry.page) == 0) {
+      return entry.render;
+    }
+  }
+  return nullptr;
+}
+
+/**
+ * @brief Reject targets that are driven locally rather than by Home Assistant.
+ *
+ * The relay and embedded-thermostat chips keep their own persisted appearance
+ * and render without Home Assistant, so a subscription must never claim them.
+ * Once those slots become user-assignable this becomes a check against whatever
+ * currently owns the slot.
+ *
+ * @param page Target page.
+ * @param component Target component.
+ * @return true when the target may be bound.
+ */
+static bool sub_target_allowed(const char *page, const char *component) {
+  if (strcmp(page, "chips") != 0) {
+    return true;
+  }
+  static constexpr const char *LOCAL_CHIPS[] = {"chip_relay1", "chip_relay2", "chip_climate"};
+  for (const char *reserved : LOCAL_CHIPS) {
+    if (strcmp(component, reserved) == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+uint16_t sub_load() {
+  SubHeader header{};
+  if (!sub_header_pref().load(&header)) {
+    ESP_LOGD(TAG, "No persisted bindings");
+    return 0;
+  }
+  sub_unverified = header.unverified;
+
+  if (header.version != SUB_FORMAT_VERSION) {
+    ESP_LOGW(TAG, "Persisted bindings use format %" PRIu8 ", expected %" PRIu8 "; discarding", header.version,
+              SUB_FORMAT_VERSION);
+    return 0;
+  }
+
+  if (header.count == 0 || header.count > SUB_MAX) {
+    ESP_LOGW(TAG, "Persisted binding count out of range (%" PRIu16 "), ignoring", header.count);
+    return 0;
+  }
+
+  sub_bindings = static_cast<SubBinding *>(sub_alloc(sizeof(SubBinding) * header.count));
+  sub_runtime = static_cast<SubRuntime *>(sub_alloc(sizeof(SubRuntime) * header.count));
+  sub_renderers = static_cast<SubRenderFn *>(sub_alloc(sizeof(SubRenderFn) * header.count));
+  if (sub_bindings == nullptr || sub_runtime == nullptr || sub_renderers == nullptr) {
+    ESP_LOGE(TAG, "Out of memory loading %" PRIu16 " bindings", header.count);
+    free(sub_bindings);
+    free(sub_runtime);
+    free(sub_renderers);
+    sub_bindings = nullptr;
+    sub_runtime = nullptr;
+    sub_renderers = nullptr;
+    return 0;
+  }
+
+  const uint16_t chunks = (header.count + SUB_CHUNK_SIZE - 1) / SUB_CHUNK_SIZE;
+  for (uint16_t chunk = 0; chunk < chunks; ++chunk) {
+    SubChunk data{};
+    if (!sub_chunk_pref(chunk).load(&data)) {
+      ESP_LOGW(TAG, "Chunk %" PRIu16 " missing; loaded %" PRIu16 " binding(s)", chunk, sub_count);
+      break;
+    }
+    for (uint16_t slot = 0; slot < SUB_CHUNK_SIZE && sub_count < header.count; ++slot) {
+      sub_bindings[sub_count] = data.bindings[slot];
+      sub_renderers[sub_count] = sub_resolve_renderer(sub_bindings[sub_count].page);
+      if (sub_renderers[sub_count] == nullptr) {
+        ESP_LOGW(TAG, "No renderer for page '%s'", sub_bindings[sub_count].page);
+      }
+      ++sub_count;
+    }
+  }  // for each chunk
+
+  ESP_LOGCONFIG(TAG, "Loaded %" PRIu16 " binding(s)", sub_count);
+  return sub_count;
+}
+
+void sub_subscribe_all() {
+#ifdef USE_API_HOMEASSISTANT_STATES
+  if (sub_count == 0) {
+    return;
+  }
+  const size_t heap_before = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+
+  for (uint16_t idx = 0; idx < sub_count; ++idx) {
+    SubBinding &binding = sub_bindings[idx];
+    if (binding.entity[0] == '\0') {
+      continue;
+    }
+
+    // The const char* overload stores the pointer without copying, so
+    // binding.entity must outlive the subscription. It does: sub_bindings is
+    // allocated once here and never resized, and a binding change restarts.
+    api::global_api_server->subscribe_home_assistant_state(
+        binding.entity, nullptr, std::function<void(StringRef)>([idx](StringRef state) {
+          SubRuntime &rt = sub_runtime[idx];
+          if (strncmp(rt.state, state.c_str(), sizeof(rt.state)) == 0) {
+            return;  // Unchanged; nothing to recompute
+          }
+          sub_copy(rt.state, sizeof(rt.state), state.c_str());
+          sub_apply(idx);
+        }));
+
+    // Climate visibility follows hvac_action when available, so the attribute
+    // needs a subscription of its own.
+    if (binding.domain == SUB_DOMAIN_CLIMATE) {
+      api::global_api_server->subscribe_home_assistant_state(
+          binding.entity, SUB_HVAC_ACTION, std::function<void(StringRef)>([idx](StringRef action) {
+            SubRuntime &rt = sub_runtime[idx];
+            if (strncmp(rt.action, action.c_str(), sizeof(rt.action)) == 0) {
+              return;  // Unchanged; nothing to recompute
+            }
+            sub_copy(rt.action, sizeof(rt.action), action.c_str());
+            sub_apply(idx);
+          }));
+    }
+  }  // for each binding
+
+  ESP_LOGI(TAG, "%" PRIu16 " binding(s) subscribed | heap cost=%d B", sub_count,
+            static_cast<int>(heap_before - heap_caps_get_free_size(MALLOC_CAP_INTERNAL)));
+#else   // USE_API_HOMEASSISTANT_STATES
+  ESP_LOGE(TAG, "api: homeassistant_states is not enabled; no subscription is possible");
+#endif  // USE_API_HOMEASSISTANT_STATES
+}
+
+void sub_push_binding(const char *page, const char *component, const char *entity, const char *device_class,
+                      const char *icon_on, const char *icon_off, uint16_t color_on, uint16_t color_off,
+                      bool inverted) {
+  if (!sub_target_allowed(page, component)) {
+    ESP_LOGW(TAG, "%s.%s is driven locally and cannot be bound", page, component);
+    return;
+  }
+
+  // The first binding after a completed or abandoned push starts a new one.
+  if (!sub_pushing) {
+    if (sub_staging == nullptr) {
+      sub_staging = static_cast<SubBinding *>(sub_alloc(sizeof(SubBinding) * SUB_MAX));
+      if (sub_staging == nullptr) {
+        ESP_LOGE(TAG, "Out of memory staging bindings");
+        return;
+      }
+    }
+    memset(sub_staging, 0, sizeof(SubBinding) * SUB_MAX);
+    sub_staged = 0;
+    sub_pushing = true;
+    ESP_LOGD(TAG, "Binding push started");
+  }
+
+  if (sub_staged >= SUB_MAX) {
+    ESP_LOGW(TAG, "More than %" PRIu16 " bindings pushed; '%s' ignored", SUB_MAX, entity);
+    return;
+  }
+
+  SubBinding &staged = sub_staging[sub_staged];
+  sub_copy(staged.entity, sizeof(staged.entity), entity);
+  sub_copy(staged.page, sizeof(staged.page), page);
+  sub_copy(staged.component, sizeof(staged.component), component);
+  sub_copy(staged.device_class, sizeof(staged.device_class), device_class);
+  staged.domain = static_cast<uint8_t>(parse_sub_domain(staged.entity));
+  staged.inverted = inverted;
+  ++sub_staged;
+
+  // Appearance is not persisted, so apply it live to the matching live binding.
+  // A component that is not yet bound picks it up after the restart.
+  for (uint16_t idx = 0; idx < sub_count; ++idx) {
+    SubBinding &live = sub_bindings[idx];
+    if (strcmp(live.page, page) != 0 || strcmp(live.component, component) != 0) {
+      continue;
+    }
+
+    // Neither of these affects the subscription, so both apply live rather
+    // than waiting for the restart that an entity change would schedule.
+    sub_copy(live.device_class, sizeof(live.device_class), device_class);
+    live.inverted = inverted;
+
+    // Appearance is not persisted, so it arrives with every push.
+    SubRuntime &rt = sub_runtime[idx];
+    sub_copy(rt.icon_on, sizeof(rt.icon_on), icon_on);
+    sub_copy(rt.icon_off, sizeof(rt.icon_off), icon_off);
+    rt.color_on = color_on;
+    rt.color_off = color_off;
+    rt.has_appearance = true;
+
+    sub_apply(idx);
+    break;
+  }  // for each live binding
+}
+
+void sub_persist(bool verified) {
+  const uint16_t chunks = (sub_staged + SUB_CHUNK_SIZE - 1) / SUB_CHUNK_SIZE;
+  for (uint16_t chunk = 0; chunk < chunks; ++chunk) {
+    SubChunk data{};
+    for (uint16_t slot = 0; slot < SUB_CHUNK_SIZE; ++slot) {
+      const uint16_t idx = (chunk * SUB_CHUNK_SIZE) + slot;
+      if (idx < sub_staged) {
+        data.bindings[slot] = sub_staging[idx];
+      }
+    }
+    sub_chunk_pref(chunk).save(&data);
+  }  // for each chunk
+
+  sub_unverified = verified ? 0 : static_cast<uint8_t>(sub_unverified + 1);
+  SubHeader header{SUB_FORMAT_VERSION, sub_staged, sub_unverified};
+  sub_header_pref().save(&header);
+  global_preferences->sync();
+
+  ESP_LOGI(TAG, "Persisted %" PRIu16 " binding(s)%s", sub_staged, verified ? "" : " (unverified)");
+}
+
+/**
+ * @brief Compare the staged set against the live one.
+ *
+ * @return true when the sets differ and a restart is required.
+ */
+static bool sub_staged_differs() {
+  if (sub_staged != sub_count) {
+    return true;
+  }
+  for (uint16_t idx = 0; idx < sub_staged; ++idx) {
+    if (!sub_binding_equal(sub_staging[idx], sub_bindings[idx])) {
+      ESP_LOGV(TAG, "Binding %" PRIu16 " changed: '%s' %s.%s -> '%s' %s.%s", idx, sub_bindings[idx].entity,
+                sub_bindings[idx].page, sub_bindings[idx].component, sub_staging[idx].entity, sub_staging[idx].page,
+                sub_staging[idx].component);
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @brief Release the staging buffer and end the current push.
+ */
+static void sub_push_release() {
+  free(sub_staging);
+  sub_staging = nullptr;
+  sub_staged = 0;
+  sub_pushing = false;
+}
+
+bool sub_push_end(uint16_t count) {
+  if (!sub_pushing) {
+    ESP_LOGW(TAG, "End marker received with no push in progress");
+    return false;
+  }
+
+  if (count != sub_staged) {
+    ESP_LOGE(TAG, "Push incomplete: %" PRIu16 " of %" PRIu16 " binding(s) received, discarding", sub_staged, count);
+    sub_push_release();
+    return false;
+  }
+
+  if (!sub_staged_differs()) {
+    ESP_LOGD(TAG, "Bindings unchanged");
+    sub_unverified = 0;
+    sub_push_release();
+    return false;
+  }
+
+  sub_persist(true);
+  sub_push_release();
+  return true;
+}
+
+bool sub_push_timeout() {
+  if (!sub_pushing) {
+    return false;
+  }
+
+  if (sub_unverified >= SUB_MAX_UNVERIFIED_COMMITS) {
+    ESP_LOGE(TAG,
+             "No end marker after %" PRIu8 " consecutive pushes; refusing to commit. "
+             "The blueprint is not sending the end marker, or the push is being truncated.",
+             sub_unverified);
+    sub_push_release();
+    return false;
+  }
+
+  if (!sub_staged_differs()) {
+    ESP_LOGW(TAG, "No end marker, but bindings are unchanged");
+    sub_push_release();
+    return false;
+  }
+
+  ESP_LOGW(TAG, "No end marker; committing %" PRIu16 " binding(s) unverified", sub_staged);
+  sub_persist(false);
+  sub_push_release();
+  return true;
+}
+
+void sub_render_all() {
+  for (uint16_t idx = 0; idx < sub_count; ++idx) {
+    sub_apply(idx);
+  }
+}
+
+void sub_dump_config() {
+  ESP_LOGCONFIG(TAG, "Subscriptions");
+  ESP_LOGCONFIG(TAG, "  Bindings: %" PRIu16 " of %" PRIu16, sub_count, SUB_MAX);
+  if (sub_unverified > 0) {
+    ESP_LOGCONFIG(TAG, "  Unverified commits: %" PRIu8, sub_unverified);
+  }
+  for (uint16_t idx = 0; idx < sub_count; ++idx) {
+    const SubBinding &binding = sub_bindings[idx];
+    ESP_LOGCONFIG(TAG, "  %s.%s <- %s%s%s", binding.page, binding.component, binding.entity,
+                  binding.inverted ? " (inverted)" : "", sub_renderers[idx] == nullptr ? " [no renderer]" : "");
+  }
+}
+
+}  // namespace esphome::nspanel_easy
+
+#endif  // NSPANEL_EASY_SUBSCRIBE

--- a/components/nspanel_easy/api_subscriptions.cpp
+++ b/components/nspanel_easy/api_subscriptions.cpp
@@ -199,7 +199,7 @@ uint16_t sub_load() {
 
   if (header.version != SUB_FORMAT_VERSION) {
     ESP_LOGW(TAG, "Persisted bindings use format %" PRIu8 ", expected %" PRIu8 "; discarding", header.version,
-              SUB_FORMAT_VERSION);
+             SUB_FORMAT_VERSION);
     return 0;
   }
 
@@ -285,15 +285,14 @@ void sub_subscribe_all() {
   }  // for each binding
 
   ESP_LOGI(TAG, "%" PRIu16 " binding(s) subscribed | heap cost=%d B", sub_count,
-            static_cast<int>(heap_before - heap_caps_get_free_size(MALLOC_CAP_INTERNAL)));
+           static_cast<int>(heap_before - heap_caps_get_free_size(MALLOC_CAP_INTERNAL)));
 #else   // USE_API_HOMEASSISTANT_STATES
   ESP_LOGE(TAG, "api: homeassistant_states is not enabled; no subscription is possible");
 #endif  // USE_API_HOMEASSISTANT_STATES
 }
 
 void sub_push_binding(const char *page, const char *component, const char *entity, const char *device_class,
-                      const char *icon_on, const char *icon_off, uint16_t color_on, uint16_t color_off,
-                      bool inverted) {
+                      const char *icon_on, const char *icon_off, uint16_t color_on, uint16_t color_off, bool inverted) {
   if (!sub_target_allowed(page, component)) {
     ESP_LOGW(TAG, "%s.%s is driven locally and cannot be bound", page, component);
     return;
@@ -387,8 +386,8 @@ static bool sub_staged_differs() {
   for (uint16_t idx = 0; idx < sub_staged; ++idx) {
     if (!sub_binding_equal(sub_staging[idx], sub_bindings[idx])) {
       ESP_LOGV(TAG, "Binding %" PRIu16 " changed: '%s' %s.%s -> '%s' %s.%s", idx, sub_bindings[idx].entity,
-                sub_bindings[idx].page, sub_bindings[idx].component, sub_staging[idx].entity, sub_staging[idx].page,
-                sub_staging[idx].component);
+               sub_bindings[idx].page, sub_bindings[idx].component, sub_staging[idx].entity, sub_staging[idx].page,
+               sub_staging[idx].component);
       return true;
     }
   }

--- a/components/nspanel_easy/api_subscriptions.cpp
+++ b/components/nspanel_easy/api_subscriptions.cpp
@@ -4,6 +4,8 @@
 
 #include "api_subscriptions.h"
 
+#include <cinttypes>
+
 #include <esp_heap_caps.h>
 
 #include "esphome/components/api/api_server.h"
@@ -193,13 +195,14 @@ uint16_t sub_load() {
     ESP_LOGD(TAG, "No persisted bindings");
     return 0;
   }
-  sub_unverified = header.unverified;
-
   if (header.version != SUB_FORMAT_VERSION) {
     ESP_LOGW(TAG, "Persisted bindings use format %" PRIu8 ", expected %" PRIu8 "; discarding", header.version,
              SUB_FORMAT_VERSION);
+    sub_unverified = 0;
     return 0;
   }
+
+  sub_unverified = header.unverified;
 
   if (header.count == 0 || header.count > SUB_MAX) {
     ESP_LOGW(TAG, "Persisted binding count out of range (%" PRIu16 "), ignoring", header.count);

--- a/components/nspanel_easy/api_subscriptions.cpp
+++ b/components/nspanel_easy/api_subscriptions.cpp
@@ -20,8 +20,6 @@ namespace esphome::nspanel_easy {
 
 static const char *const TAG = "nspanel.api.sub";
 
-esphome::nextion::Nextion *nextion_display = nullptr;
-
 SubBinding *sub_bindings = nullptr;
 SubRuntime *sub_runtime = nullptr;
 SubRenderFn *sub_renderers = nullptr;

--- a/components/nspanel_easy/api_subscriptions.h
+++ b/components/nspanel_easy/api_subscriptions.h
@@ -33,10 +33,6 @@
  * on/off semantics cannot drift between component types.
  */
 
-namespace esphome::nextion {
-class Nextion;
-}  // namespace esphome::nextion
-
 namespace esphome::nspanel_easy {
 
 /// @brief Persisted format version. Bump whenever SubBinding's layout changes.
@@ -155,15 +151,6 @@ struct SubRuntime {
  * @param visible Whether the component should be shown.
  */
 using SubRenderFn = void (*)(const SubBinding &binding, const SubRuntime &rt, const char *state, bool visible);
-
-/**
- * @brief Display used by renderers.
- *
- * ESPHome declares component pointers with internal linkage in main.cpp, so
- * they cannot be reached with extern. The pointer is handed over once from a
- * lambda during boot instead.
- */
-extern esphome::nextion::Nextion *nextion_display;
 
 /// @brief Live bindings, allocated once at boot to the persisted count.
 extern SubBinding *sub_bindings;

--- a/components/nspanel_easy/api_subscriptions.h
+++ b/components/nspanel_easy/api_subscriptions.h
@@ -89,12 +89,12 @@ enum SubEntityState : uint8_t {
  * once and pushes it, and ESPHome only toggles visibility.
  */
 enum SubDomain : uint8_t {
-  SUB_DOMAIN_GENERIC = 0,    ///< Appearance supplied by the blueprint
-  SUB_DOMAIN_ALARM,          ///< alarm_control_panel
-  SUB_DOMAIN_CLIMATE,        ///< climate; also subscribes to the hvac_action attribute
-  SUB_DOMAIN_COVER,          ///< cover; device_class dependent
-  SUB_DOMAIN_LOCK,           ///< lock
-  SUB_DOMAIN_WATER_HEATER,   ///< water_heater
+  SUB_DOMAIN_GENERIC = 0,   ///< Appearance supplied by the blueprint
+  SUB_DOMAIN_ALARM,         ///< alarm_control_panel
+  SUB_DOMAIN_CLIMATE,       ///< climate; also subscribes to the hvac_action attribute
+  SUB_DOMAIN_COVER,         ///< cover; device_class dependent
+  SUB_DOMAIN_LOCK,          ///< lock
+  SUB_DOMAIN_WATER_HEATER,  ///< water_heater
 };
 
 /// @brief Icon and colour for a component in a given state.
@@ -216,8 +216,10 @@ inline SubDomain parse_sub_domain(const char *entity_id) {
     SubDomain domain;
   };
   static constexpr DomainEntry DOMAINS[] = {
-      {"alarm_control_panel", SUB_DOMAIN_ALARM}, {"climate", SUB_DOMAIN_CLIMATE},
-      {"cover", SUB_DOMAIN_COVER},               {"lock", SUB_DOMAIN_LOCK},
+      {"alarm_control_panel", SUB_DOMAIN_ALARM},
+      {"climate", SUB_DOMAIN_CLIMATE},
+      {"cover", SUB_DOMAIN_COVER},
+      {"lock", SUB_DOMAIN_LOCK},
       {"water_heater", SUB_DOMAIN_WATER_HEATER},
   };
   for (const DomainEntry &entry : DOMAINS) {
@@ -247,8 +249,8 @@ inline SubEntityState evaluate_sub_state(SubDomain domain, const char *state) {
   switch (domain) {
     case SUB_DOMAIN_ALARM: {
       static constexpr const char *ON_STATES[] = {
-          "armed_home", "armed_away", "armed_night", "armed_vacation", "armed_custom_bypass", "armed_bypass",
-          "triggered",
+          "armed_home",          "armed_away",   "armed_night", "armed_vacation",
+          "armed_custom_bypass", "armed_bypass", "triggered",
       };
       static constexpr const char *TRANSITIONAL_STATES[] = {"arming", "pending", "disarming"};
       if (sub_state_in(state, ON_STATES)) {

--- a/components/nspanel_easy/api_subscriptions.h
+++ b/components/nspanel_easy/api_subscriptions.h
@@ -1,0 +1,583 @@
+// api_subscriptions.h
+
+#pragma once
+
+#ifdef NSPANEL_EASY_SUBSCRIBE
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+#include "all_icons.h"
+#include "nextion_constants.h"
+
+/**
+ * @file subscriptions.h
+ * @brief Direct Home Assistant state subscriptions for NSPanel components.
+ *
+ * The blueprint pushes a set of bindings (which entity drives which component)
+ * once per session. ESPHome persists them, re-subscribes on every boot, and
+ * renders state changes locally, so no automation runs per state change.
+ *
+ * Why persistence is load-bearing:
+ * APIConnection::process_state_subscriptions_() latches state_subs_at_ to -1
+ * once the burst that follows SubscribeHomeAssistantStatesRequest drains, so a
+ * subscription registered later is stored and never sent. The blueprint can
+ * only push after the API is connected, which is always after that burst.
+ * Bindings therefore take effect on the following boot, and a binding change
+ * schedules a restart. Should ESPHome gain runtime subscriptions, the
+ * persistence layer and the restart can both be removed.
+ *
+ * Rendering is dispatched through a function pointer resolved from the target
+ * page at load time. Classification lives here and never inside a renderer, so
+ * on/off semantics cannot drift between component types.
+ */
+
+namespace esphome::nextion {
+class Nextion;
+}  // namespace esphome::nextion
+
+namespace esphome::nspanel_easy {
+
+/// @brief Persisted format version. Bump whenever SubBinding's layout changes.
+static constexpr uint8_t SUB_FORMAT_VERSION = 1;
+
+/// @brief Upper bound on bindings; storage is allocated to the configured count, not this.
+#ifndef NSPANEL_EASY_SUB_MAX
+#define NSPANEL_EASY_SUB_MAX 128
+#endif  // NSPANEL_EASY_SUB_MAX
+static constexpr uint16_t SUB_MAX = NSPANEL_EASY_SUB_MAX;
+
+/// @brief Bindings per persisted NVS chunk. Keeps the sync() compare-copy spike small.
+static constexpr uint16_t SUB_CHUNK_SIZE = 16;
+
+/// @brief Number of NVS chunks needed to hold SUB_MAX bindings.
+static constexpr uint16_t SUB_CHUNK_COUNT = (SUB_MAX + SUB_CHUNK_SIZE - 1) / SUB_CHUNK_SIZE;
+
+static constexpr uint8_t SUB_ENTITY_LEN = 64;        ///< Longest stored entity_id
+static constexpr uint8_t SUB_PAGE_LEN = 12;          ///< Longest stored page name ("screensaver")
+static constexpr uint8_t SUB_COMPONENT_LEN = 16;     ///< Longest stored component name
+static constexpr uint8_t SUB_DEVICE_CLASS_LEN = 16;  ///< Longest device_class in use ("garage_door")
+static constexpr uint8_t SUB_STATE_LEN = 24;         ///< Longest state ("armed_custom_bypass" is 19)
+
+/// @brief Attribute subscribed alongside the state for climate bindings.
+static constexpr const char SUB_HVAC_ACTION[] = "hvac_action";
+
+/// @brief Consecutive unverified commits tolerated before refusing to commit again.
+static constexpr uint8_t SUB_MAX_UNVERIFIED_COMMITS = 3;
+
+/**
+ * @brief Classification of a Home Assistant state string.
+ *
+ * Tri-state plus a transitional case. A state belonging to no known set hides
+ * the component in both polarities, so an unrecognised value never lights an
+ * inverted component by accident. A transitional state shows it in both, so
+ * movement is surfaced regardless of how the binding is configured.
+ */
+enum SubEntityState : uint8_t {
+  SUB_STATE_NEITHER = 0,   ///< Unusable or unrecognised; hidden either way
+  SUB_STATE_OFF,           ///< Inactive for this domain
+  SUB_STATE_ON,            ///< Active for this domain
+  SUB_STATE_TRANSITIONAL,  ///< In motion; shown in both polarities
+};
+
+/**
+ * @brief Domains whose visible state set spans more than one state.
+ *
+ * Only these need on-device icon and colour resolution. Every other domain has
+ * a single visible state per polarity, so the blueprint resolves the appearance
+ * once and pushes it, and ESPHome only toggles visibility.
+ */
+enum SubDomain : uint8_t {
+  SUB_DOMAIN_GENERIC = 0,    ///< Appearance supplied by the blueprint
+  SUB_DOMAIN_ALARM,          ///< alarm_control_panel
+  SUB_DOMAIN_CLIMATE,        ///< climate; also subscribes to the hvac_action attribute
+  SUB_DOMAIN_COVER,          ///< cover; device_class dependent
+  SUB_DOMAIN_LOCK,           ///< lock
+  SUB_DOMAIN_WATER_HEATER,   ///< water_heater
+};
+
+/// @brief Icon and colour for a component in a given state.
+struct SubAppearance {
+  const char *icon;  ///< UTF-8 MDI codepoint, or nullptr when the blueprint supplies it
+  uint16_t color;    ///< RGB565 foreground colour
+};
+
+/**
+ * @brief Persisted binding between a Home Assistant entity and a component.
+ *
+ * The entity field is the storage the API points at: the const char* overload
+ * of subscribe_home_assistant_state() keeps the pointer without copying. The
+ * binding array is allocated once at boot and never resized, so the pointer
+ * stays valid for the lifetime of the process.
+ */
+struct SubBinding {
+  char entity[SUB_ENTITY_LEN];              ///< entity_id; empty means the slot is unused
+  char page[SUB_PAGE_LEN];                  ///< Target page, e.g. "chips"
+  char component[SUB_COMPONENT_LEN];        ///< Target component, e.g. "chip01"
+  char device_class[SUB_DEVICE_CLASS_LEN];  ///< HA device_class; cover only, empty when unset
+  uint8_t domain;                           ///< SubDomain, derived from entity at bind time
+  bool inverted;                            ///< Show while the entity is inactive
+};
+
+/// @brief One persisted NVS chunk.
+struct SubChunk {
+  SubBinding bindings[SUB_CHUNK_SIZE];
+};
+
+/**
+ * @brief Runtime state for a binding. Never persisted.
+ *
+ * Appearance arrives with the binding push and is not stored, so a component
+ * stays hidden after a boot until the blueprint reconnects and pushes again.
+ */
+struct SubRuntime {
+  char state[SUB_STATE_LEN];   ///< Last raw state string
+  char action[SUB_STATE_LEN];  ///< Last hvac_action value; climate bindings only
+  char icon_on[4];             ///< Blueprint-supplied icon for the active state
+  char icon_off[4];            ///< Blueprint-supplied icon for the inactive state
+  uint16_t color_on;           ///< Blueprint-supplied colour for the active state
+  uint16_t color_off;          ///< Blueprint-supplied colour for the inactive state
+  SubEntityState last_state;   ///< Classification of the effective state
+  bool has_appearance;         ///< Blueprint has pushed appearance in this session
+};
+
+/**
+ * @brief Renders a binding onto its target component.
+ *
+ * Receives an already-classified state so that on/off semantics stay in one
+ * place. A renderer decides only how to draw, never whether the entity counts
+ * as active.
+ *
+ * @param binding The binding being rendered.
+ * @param rt Runtime state, including blueprint-supplied appearance.
+ * @param state Effective state string; hvac_action for climate when usable.
+ * @param visible Whether the component should be shown.
+ */
+using SubRenderFn = void (*)(const SubBinding &binding, const SubRuntime &rt, const char *state, bool visible);
+
+/**
+ * @brief Display used by renderers.
+ *
+ * ESPHome declares component pointers with internal linkage in main.cpp, so
+ * they cannot be reached with extern. The pointer is handed over once from a
+ * lambda during boot instead.
+ */
+extern esphome::nextion::Nextion *nextion_display;
+
+/// @brief Live bindings, allocated once at boot to the persisted count.
+extern SubBinding *sub_bindings;
+
+/// @brief Runtime state, parallel to sub_bindings.
+extern SubRuntime *sub_runtime;
+
+/// @brief Render function per binding, resolved from the target page at load time.
+extern SubRenderFn *sub_renderers;
+
+/// @brief Number of live bindings.
+extern uint16_t sub_count;
+
+/**
+ * @brief Test whether a state string appears in a literal state list.
+ *
+ * @tparam N Number of entries, deduced from the array.
+ * @param state State string to test.
+ * @param list State literals.
+ * @return true when the state matches one of the entries.
+ */
+template<size_t N> inline bool sub_state_in(const char *state, const char *const (&list)[N]) {
+  for (size_t i = 0; i < N; ++i) {
+    if (strcmp(state, list[i]) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// @brief States that carry no usable value, for any domain.
+static constexpr const char *SUB_UNUSABLE_STATES[] = {"unknown", "unavailable", "none", "None"};
+
+/**
+ * @brief Derive the domain from an entity_id.
+ *
+ * @param entity_id Full entity_id, e.g. "cover.garage_door".
+ * @return Matching SubDomain, or SUB_DOMAIN_GENERIC when no on-device
+ *         appearance resolution is needed.
+ */
+inline SubDomain parse_sub_domain(const char *entity_id) {
+  const char *dot = strchr(entity_id, '.');
+  if (dot == nullptr) {
+    return SUB_DOMAIN_GENERIC;
+  }
+  const size_t len = static_cast<size_t>(dot - entity_id);
+
+  struct DomainEntry {
+    const char *name;
+    SubDomain domain;
+  };
+  static constexpr DomainEntry DOMAINS[] = {
+      {"alarm_control_panel", SUB_DOMAIN_ALARM}, {"climate", SUB_DOMAIN_CLIMATE},
+      {"cover", SUB_DOMAIN_COVER},               {"lock", SUB_DOMAIN_LOCK},
+      {"water_heater", SUB_DOMAIN_WATER_HEATER},
+  };
+  for (const DomainEntry &entry : DOMAINS) {
+    if (strncmp(entity_id, entry.name, len) == 0 && entry.name[len] == '\0') {
+      return entry.domain;
+    }
+  }
+  return SUB_DOMAIN_GENERIC;
+}
+
+/**
+ * @brief Classify a raw Home Assistant state string for a given domain.
+ *
+ * Deliberately not a port of the blueprint's enum.states, which omits
+ * armed_night, disagrees with itself over armed_bypass vs armed_custom_bypass,
+ * never resolves water_heater operation modes, and lacks "cool".
+ *
+ * @param domain Domain of the bound entity.
+ * @param state Raw state string, or the tracked attribute value.
+ * @return Classification, or SUB_STATE_TRANSITIONAL while moving.
+ */
+inline SubEntityState evaluate_sub_state(SubDomain domain, const char *state) {
+  if (state == nullptr || state[0] == '\0' || sub_state_in(state, SUB_UNUSABLE_STATES)) {
+    return SUB_STATE_NEITHER;
+  }
+
+  switch (domain) {
+    case SUB_DOMAIN_ALARM: {
+      static constexpr const char *ON_STATES[] = {
+          "armed_home", "armed_away", "armed_night", "armed_vacation", "armed_custom_bypass", "armed_bypass",
+          "triggered",
+      };
+      static constexpr const char *TRANSITIONAL_STATES[] = {"arming", "pending", "disarming"};
+      if (sub_state_in(state, ON_STATES)) {
+        return SUB_STATE_ON;
+      }
+      if (sub_state_in(state, TRANSITIONAL_STATES)) {
+        return SUB_STATE_TRANSITIONAL;
+      }
+      return (strcmp(state, "disarmed") == 0) ? SUB_STATE_OFF : SUB_STATE_NEITHER;
+    }  // case SUB_DOMAIN_ALARM
+
+    case SUB_DOMAIN_CLIMATE: {
+      // Receives hvac_action when that attribute holds a usable value, and the
+      // hvac mode otherwise, so both vocabularies are covered here.
+      static constexpr const char *ON_STATES[] = {
+          "heat", "heating", "cool", "cooling", "heat_cool", "dry", "drying", "fan", "fan_only", "auto",
+      };
+      static constexpr const char *OFF_STATES[] = {"off", "idle"};
+      if (sub_state_in(state, ON_STATES)) {
+        return SUB_STATE_ON;
+      }
+      return sub_state_in(state, OFF_STATES) ? SUB_STATE_OFF : SUB_STATE_NEITHER;
+    }  // case SUB_DOMAIN_CLIMATE
+
+    case SUB_DOMAIN_COVER: {
+      static constexpr const char *TRANSITIONAL_STATES[] = {"opening", "closing"};
+      if (sub_state_in(state, TRANSITIONAL_STATES)) {
+        return SUB_STATE_TRANSITIONAL;
+      }
+      if (strcmp(state, "open") == 0) {
+        return SUB_STATE_ON;
+      }
+      return (strcmp(state, "closed") == 0) ? SUB_STATE_OFF : SUB_STATE_NEITHER;
+    }  // case SUB_DOMAIN_COVER
+
+    case SUB_DOMAIN_LOCK: {
+      // "jammed" counts as active: the lock is not securing anything, which is
+      // precisely what a lock indicator exists to surface.
+      static constexpr const char *ON_STATES[] = {"unlocked", "open", "jammed"};
+      static constexpr const char *TRANSITIONAL_STATES[] = {"locking", "unlocking", "opening"};
+      if (sub_state_in(state, ON_STATES)) {
+        return SUB_STATE_ON;
+      }
+      if (sub_state_in(state, TRANSITIONAL_STATES)) {
+        return SUB_STATE_TRANSITIONAL;
+      }
+      return (strcmp(state, "locked") == 0) ? SUB_STATE_OFF : SUB_STATE_NEITHER;
+    }  // case SUB_DOMAIN_LOCK
+
+    case SUB_DOMAIN_WATER_HEATER: {
+      // The state of a water_heater is its current operation mode.
+      static constexpr const char *ON_STATES[] = {
+          "on", "eco", "electric", "gas", "heat_pump", "high_demand", "performance",
+      };
+      if (sub_state_in(state, ON_STATES)) {
+        return SUB_STATE_ON;
+      }
+      return (strcmp(state, "off") == 0) ? SUB_STATE_OFF : SUB_STATE_NEITHER;
+    }  // case SUB_DOMAIN_WATER_HEATER
+
+    case SUB_DOMAIN_GENERIC:
+    default: {
+      static constexpr const char *ON_STATES[] = {"on", "true", "True", "1", "active", "home", "playing"};
+      static constexpr const char *OFF_STATES[] = {
+          "off", "false", "False", "0", "not_home", "idle", "standby", "paused",
+      };
+      if (sub_state_in(state, ON_STATES)) {
+        return SUB_STATE_ON;
+      }
+      return sub_state_in(state, OFF_STATES) ? SUB_STATE_OFF : SUB_STATE_NEITHER;
+    }  // case SUB_DOMAIN_GENERIC
+  }  // switch domain
+}
+
+/**
+ * @brief Resolve visibility from a classification and the inversion flag.
+ *
+ * @param eval Classification returned by evaluate_sub_state().
+ * @param inverted Whether the binding is configured as inverted.
+ * @return true when the component should be shown.
+ */
+inline bool sub_visible(SubEntityState eval, bool inverted) {
+  if (eval == SUB_STATE_TRANSITIONAL) {
+    return true;  // Movement is surfaced regardless of the configured polarity
+  }
+  return inverted ? (eval == SUB_STATE_OFF) : (eval == SUB_STATE_ON);
+}
+
+/**
+ * @brief Per-device_class cover icons, one per state.
+ *
+ * Mirrors device_class_icons.cover in the blueprint. Device classes sharing the
+ * same artwork are listed separately rather than aliased, so a future
+ * divergence is a one-line edit. The final row, with a null device_class, is the
+ * fallback for covers with no device class or an unrecognised one, and matches
+ * nextion.icon.domain.cover.
+ */
+struct CoverIcons {
+  const char *device_class;  ///< HA cover device_class, or nullptr for the fallback row
+  const char *open;          ///< Icon while fully open
+  const char *opening;       ///< Icon while opening
+  const char *closed;        ///< Icon while fully closed
+  const char *closing;       ///< Icon while closing
+};
+
+static constexpr CoverIcons COVER_ICONS[] = {
+    {"awning", Icons::MDI_WINDOW_SHUTTER_OPEN, Icons::MDI_ARROW_UP_BOX, Icons::MDI_WINDOW_SHUTTER,
+     Icons::MDI_ARROW_DOWN_BOX},
+    {"blind", Icons::MDI_BLINDS_HORIZONTAL, Icons::MDI_ARROW_UP_BOX, Icons::MDI_BLINDS_HORIZONTAL_CLOSED,
+     Icons::MDI_ARROW_DOWN_BOX},
+    {"curtain", Icons::MDI_CURTAINS, Icons::MDI_ARROW_SPLIT_VERTICAL, Icons::MDI_CURTAINS_CLOSED,
+     Icons::MDI_ARROW_COLLAPSE_HORIZONTAL},
+    {"curtains", Icons::MDI_CURTAINS, Icons::MDI_ARROW_SPLIT_VERTICAL, Icons::MDI_CURTAINS_CLOSED,
+     Icons::MDI_ARROW_COLLAPSE_HORIZONTAL},
+    {"damper", Icons::MDI_CIRCLE, Icons::MDI_CIRCLE, Icons::MDI_CIRCLE_SLICE_8, Icons::MDI_CIRCLE},
+    {"door", Icons::MDI_DOOR_OPEN, Icons::MDI_DOOR_OPEN, Icons::MDI_DOOR_CLOSED, Icons::MDI_DOOR_OPEN},
+    {"garage", Icons::MDI_GARAGE_OPEN, Icons::MDI_ARROW_UP_BOX, Icons::MDI_GARAGE, Icons::MDI_ARROW_DOWN_BOX},
+    {"garage_door", Icons::MDI_GARAGE_OPEN, Icons::MDI_ARROW_UP_BOX, Icons::MDI_GARAGE, Icons::MDI_ARROW_DOWN_BOX},
+    {"gate", Icons::MDI_GATE_OPEN, Icons::MDI_GATE_ARROW_LEFT, Icons::MDI_GATE, Icons::MDI_GATE_ARROW_RIGHT},
+    {"shade", Icons::MDI_ROLLER_SHADE, Icons::MDI_ARROW_UP_BOX, Icons::MDI_ROLLER_SHADE_CLOSED,
+     Icons::MDI_ARROW_DOWN_BOX},
+    {"shutter", Icons::MDI_WINDOW_SHUTTER_OPEN, Icons::MDI_ARROW_UP_BOX, Icons::MDI_WINDOW_SHUTTER,
+     Icons::MDI_ARROW_DOWN_BOX},
+    {"window", Icons::MDI_WINDOW_OPEN, Icons::MDI_ARROW_UP_BOX, Icons::MDI_WINDOW_CLOSED, Icons::MDI_ARROW_DOWN_BOX},
+    {nullptr, Icons::MDI_BLINDS, Icons::MDI_BLINDS, Icons::MDI_BLINDS, Icons::MDI_BLINDS},
+};
+
+/// @brief Index of the fallback row in COVER_ICONS (the one with a null device_class).
+static constexpr size_t COVER_ICONS_FALLBACK = (sizeof(COVER_ICONS) / sizeof(COVER_ICONS[0])) - 1;
+
+/**
+ * @brief Resolve the icon and colour for a component in its current state.
+ *
+ * Only meaningful for domains whose appearance varies across the visible state
+ * set. SUB_DOMAIN_GENERIC returns a null icon, signalling the caller to use the
+ * appearance the blueprint pushed.
+ *
+ * @param domain Domain of the bound entity.
+ * @param device_class HA device_class, or an empty string when unset. Cover only.
+ * @param state Effective state string; hvac_action for climate when usable.
+ * @param color_on Fallback colour for active states.
+ * @param color_off Fallback colour for inactive states.
+ * @return Icon codepoint and RGB565 colour.
+ */
+inline SubAppearance resolve_sub_appearance(SubDomain domain, const char *device_class, const char *state,
+                                            uint16_t color_on, uint16_t color_off) {
+  switch (domain) {
+    case SUB_DOMAIN_ALARM: {
+      if (strcmp(state, "armed_home") == 0)
+        return {Icons::MDI_SHIELD_HOME_OUTLINE, Colors::RGB565_GREEN};
+      if (strcmp(state, "armed_away") == 0)
+        return {Icons::MDI_SHIELD_LOCK_OUTLINE, Colors::RGB565_GREEN};
+      if (strcmp(state, "armed_night") == 0)
+        return {Icons::MDI_SHIELD_MOON_OUTLINE, Colors::RGB565_GREEN};
+      if (strcmp(state, "armed_vacation") == 0)
+        return {Icons::MDI_SHIELD_AIRPLANE_OUTLINE, Colors::RGB565_GREEN};
+      if (strcmp(state, "armed_custom_bypass") == 0 || strcmp(state, "armed_bypass") == 0)
+        return {Icons::MDI_SHIELD_HALF_FULL, Colors::RGB565_GREEN};
+      if (strcmp(state, "triggered") == 0)
+        return {Icons::MDI_SHIELD_ALERT_OUTLINE, Colors::RGB565_RED};
+      if (strcmp(state, "arming") == 0 || strcmp(state, "pending") == 0)
+        return {Icons::MDI_SHIELD_OUTLINE, Colors::RGB565_YELLOW};
+      if (strcmp(state, "disarming") == 0)
+        return {Icons::MDI_SHIELD_OFF_OUTLINE, Colors::RGB565_YELLOW};
+      if (strcmp(state, "disarmed") == 0)
+        return {Icons::MDI_SHIELD_OFF_OUTLINE, color_off};
+      return {Icons::MDI_SHIELD, color_on};
+    }  // case SUB_DOMAIN_ALARM
+
+    case SUB_DOMAIN_CLIMATE: {
+      // heat_cool is tested before heat, and fan_only before fan, so that the
+      // more specific mode wins — the blueprint relies on substring order here.
+      if (strcmp(state, "off") == 0)
+        return {Icons::MDI_THERMOSTAT, color_off};
+      if (strcmp(state, "heat_cool") == 0)
+        return {Icons::MDI_AUTORENEW, Colors::RGB565_YELLOW};
+      if (strcmp(state, "heating") == 0 || strcmp(state, "heat") == 0)
+        return {Icons::MDI_THERMOMETER_LINES, Colors::RGB565_DEEP_ORANGE};
+      if (strcmp(state, "cooling") == 0 || strcmp(state, "cool") == 0)
+        return {Icons::MDI_SNOWFLAKE, Colors::RGB565_BLUE};
+      if (strcmp(state, "drying") == 0 || strcmp(state, "dry") == 0)
+        return {Icons::MDI_WATER_PERCENT, Colors::RGB565_ORANGE};
+      if (strcmp(state, "fan_only") == 0 || strcmp(state, "fan") == 0)
+        return {Icons::MDI_FAN, Colors::RGB565_CYAN};
+      if (strcmp(state, "auto") == 0)
+        return {Icons::MDI_REFRESH_AUTO, Colors::RGB565_GREEN};
+      if (strcmp(state, "idle") == 0)
+        return {Icons::MDI_THERMOMETER, color_off};
+      return {Icons::MDI_THERMOSTAT, color_on};
+    }  // case SUB_DOMAIN_CLIMATE
+
+    case SUB_DOMAIN_COVER: {
+      const CoverIcons *row = &COVER_ICONS[COVER_ICONS_FALLBACK];
+      if (device_class != nullptr && device_class[0] != '\0') {
+        for (const CoverIcons &candidate : COVER_ICONS) {
+          if (candidate.device_class != nullptr && strcmp(device_class, candidate.device_class) == 0) {
+            row = &candidate;
+            break;
+          }
+        }
+      }
+      if (strcmp(state, "opening") == 0)
+        return {row->opening, Colors::RGB565_YELLOW};
+      if (strcmp(state, "closing") == 0)
+        return {row->closing, Colors::RGB565_YELLOW};
+      if (strcmp(state, "closed") == 0)
+        return {row->closed, color_off};
+      return {row->open, color_on};
+    }  // case SUB_DOMAIN_COVER
+
+    case SUB_DOMAIN_LOCK: {
+      if (strcmp(state, "locked") == 0)
+        return {Icons::MDI_LOCK, Colors::RGB565_GREEN};
+      if (strcmp(state, "unlocked") == 0 || strcmp(state, "open") == 0)
+        return {Icons::MDI_LOCK_OPEN_VARIANT, Colors::RGB565_RED};
+      if (strcmp(state, "locking") == 0 || strcmp(state, "unlocking") == 0 || strcmp(state, "opening") == 0)
+        return {Icons::MDI_LOCK_CLOCK, Colors::RGB565_YELLOW};
+      return {Icons::MDI_LOCK_ALERT, Colors::RGB565_RED};  // jammed, or anything unrecognised
+    }  // case SUB_DOMAIN_LOCK
+
+    case SUB_DOMAIN_WATER_HEATER: {
+      if (strcmp(state, "off") == 0)
+        return {Icons::MDI_WATER_BOILER_OFF, color_off};
+      if (strcmp(state, "on") == 0)
+        return {Icons::MDI_WATER_BOILER, Colors::RGB565_ORANGE};
+      if (strcmp(state, "eco") == 0)
+        return {Icons::MDI_LEAF, Colors::RGB565_GREEN};
+      if (strcmp(state, "electric") == 0)
+        return {Icons::MDI_LIGHTNING_BOLT, Colors::RGB565_YELLOW};
+      if (strcmp(state, "gas") == 0)
+        return {Icons::MDI_FIRE, Colors::RGB565_DEEP_ORANGE};
+      if (strcmp(state, "heat_pump") == 0)
+        return {Icons::MDI_HEAT_PUMP, Colors::RGB565_BLUE};
+      if (strcmp(state, "performance") == 0)
+        return {Icons::MDI_HEAT_WAVE, Colors::RGB565_RED};
+      if (strcmp(state, "high_demand") == 0)
+        return {Icons::MDI_SPEEDOMETER, Colors::RGB565_RED};
+      return {Icons::MDI_WATER_BOILER, color_on};
+    }  // case SUB_DOMAIN_WATER_HEATER
+
+    case SUB_DOMAIN_GENERIC:
+    default:
+      return {nullptr, color_on};  // Caller uses the blueprint-supplied appearance
+  }  // switch domain
+}
+
+//
+// Engine API. Implemented in subscriptions.cpp.
+//
+
+/**
+ * @brief Resolve the render function for a target page.
+ *
+ * @param page Target page name as pushed by the blueprint.
+ * @return Render function, or nullptr when the page has no renderer.
+ */
+SubRenderFn sub_resolve_renderer(const char *page);
+
+/**
+ * @brief Load persisted bindings, allocate storage, and resolve renderers.
+ *
+ * Call once from boot_early_routines, before the API connects.
+ *
+ * @return Number of bindings loaded.
+ */
+uint16_t sub_load();
+
+/**
+ * @brief Register a Home Assistant state subscription for every loaded binding.
+ *
+ * Must run before the API connects: subscriptions added after the initial burst
+ * are stored by ESPHome and never sent.
+ */
+void sub_subscribe_all();
+
+/**
+ * @brief Accept one binding from the blueprint's push.
+ *
+ * The first call after a completed or abandoned push implicitly starts a new
+ * one. Appearance is applied to the live binding immediately when the target
+ * matches; the entity is staged and only takes effect after a restart.
+ *
+ * @param page Target page.
+ * @param component Target component.
+ * @param entity Home Assistant entity_id.
+ * @param device_class HA device_class, or empty.
+ * @param icon_on Icon for the active state, or empty to resolve on-device.
+ * @param icon_off Icon for the inactive state, or empty.
+ * @param color_on RGB565 colour for the active state.
+ * @param color_off RGB565 colour for the inactive state.
+ * @param inverted Show while the entity is inactive.
+ */
+void sub_push_binding(const char *page, const char *component, const char *entity, const char *device_class,
+                      const char *icon_on, const char *icon_off, uint16_t color_on, uint16_t color_off, bool inverted);
+
+/**
+ * @brief Close the blueprint's push.
+ *
+ * @param count Number of bindings the blueprint sent. A mismatch discards the
+ *              push and leaves the persisted set untouched.
+ * @return true when the staged set differs from the persisted one and a restart
+ *         is required.
+ */
+bool sub_push_end(uint16_t count);
+
+/**
+ * @brief Commit a push that never received its end marker.
+ *
+ * Called from the watchdog timeout. Refuses to commit after
+ * SUB_MAX_UNVERIFIED_COMMITS consecutive unverified commits, so a systematically
+ * failing push cannot produce a boot loop.
+ *
+ * @return true when a restart is required.
+ */
+bool sub_push_timeout();
+
+/**
+ * @brief Persist the staged set and clear the unverified-commit counter.
+ *
+ * @param verified Whether the push was confirmed by a matching end marker.
+ */
+void sub_persist(bool verified);
+
+/// @brief Re-render every binding from its last known state.
+void sub_render_all();
+
+/// @brief Log the loaded bindings during dump_config.
+void sub_dump_config();
+
+}  // namespace esphome::nspanel_easy
+
+#endif  // NSPANEL_EASY_SUBSCRIBE

--- a/components/nspanel_easy/api_subscriptions.h
+++ b/components/nspanel_easy/api_subscriptions.h
@@ -12,7 +12,7 @@
 #include "nextion_constants.h"
 
 /**
- * @file subscriptions.h
+ * @file api_subscriptions.h
  * @brief Direct Home Assistant state subscriptions for NSPanel components.
  *
  * The blueprint pushes a set of bindings (which entity drives which component)
@@ -498,7 +498,7 @@ inline SubAppearance resolve_sub_appearance(SubDomain domain, const char *device
 }
 
 //
-// Engine API. Implemented in subscriptions.cpp.
+// Engine API. Implemented in api_subscriptions.cpp.
 //
 
 /**

--- a/components/nspanel_easy/api_subscriptions.h
+++ b/components/nspanel_easy/api_subscriptions.h
@@ -253,7 +253,8 @@ inline SubEntityState evaluate_sub_state(SubDomain domain, const char *state) {
       // Receives hvac_action when that attribute holds a usable value, and the
       // hvac mode otherwise, so both vocabularies are covered here.
       static constexpr const char *ON_STATES[] = {
-          "heat", "heating", "cool", "cooling", "heat_cool", "dry", "drying", "fan", "fan_only", "auto",
+          "heat",    "heating", "cool",       "cooling",    "heat_cool", "dry",
+          "drying",  "fan",     "fan_only",   "auto",       "preheating", "defrosting",
       };
       static constexpr const char *OFF_STATES[] = {"off", "idle"};
       if (sub_state_in(state, ON_STATES)) {
@@ -422,6 +423,10 @@ inline SubAppearance resolve_sub_appearance(SubDomain domain, const char *device
         return {Icons::MDI_WATER_PERCENT, Colors::RGB565_ORANGE};
       if (strcmp(state, "fan_only") == 0 || strcmp(state, "fan") == 0)
         return {Icons::MDI_FAN, Colors::RGB565_CYAN};
+      if (strcmp(state, "preheating") == 0)
+        return {Icons::MDI_HEAT_WAVE, Colors::RGB565_DEEP_ORANGE};
+      if (strcmp(state, "defrosting") == 0)
+        return {Icons::MDI_SNOWFLAKE_MELT, Colors::RGB565_BLUE};
       if (strcmp(state, "auto") == 0)
         return {Icons::MDI_REFRESH_AUTO, Colors::RGB565_GREEN};
       if (strcmp(state, "idle") == 0)

--- a/components/nspanel_easy/api_subscriptions.h
+++ b/components/nspanel_easy/api_subscriptions.h
@@ -253,8 +253,8 @@ inline SubEntityState evaluate_sub_state(SubDomain domain, const char *state) {
       // Receives hvac_action when that attribute holds a usable value, and the
       // hvac mode otherwise, so both vocabularies are covered here.
       static constexpr const char *ON_STATES[] = {
-          "heat",    "heating", "cool",       "cooling",    "heat_cool", "dry",
-          "drying",  "fan",     "fan_only",   "auto",       "preheating", "defrosting",
+          "heat",   "heating", "cool",     "cooling", "heat_cool",  "dry",
+          "drying", "fan",     "fan_only", "auto",    "preheating", "defrosting",
       };
       static constexpr const char *OFF_STATES[] = {"off", "idle"};
       if (sub_state_in(state, ON_STATES)) {

--- a/components/nspanel_easy/chips.cpp
+++ b/components/nspanel_easy/chips.cpp
@@ -5,10 +5,87 @@
 #include "chips.h"
 #include <string>
 
+#ifdef NSPANEL_EASY_SUBSCRIBE
+#include "esphome/components/nextion/nextion.h"
+#include "esphome/core/log.h"
+#endif  // NSPANEL_EASY_SUBSCRIBE
+
 namespace esphome::nspanel_easy {
 
 ChipState chip_states[CHIP_COUNT] = {};
 bool is_chips_page = false;
+
+#ifdef NSPANEL_EASY_SUBSCRIBE
+
+static const char *const TAG = "nspanel.chips.sub";
+
+void chip_sub_render(const SubBinding &binding, const SubRuntime &rt, const char *state, bool visible) {
+  const uint8_t idx = find_chip_index(binding.component);
+  if (idx == UINT8_MAX) {
+    ESP_LOGW(TAG, "'%s' is not a chip component", binding.component);
+    return;
+  }
+
+  if (nextion_display == nullptr) {
+    return;  // Boot has not handed the display over yet
+  }
+
+  ChipState &the_chip = chip_states[idx];
+  the_chip.subscribed = true;  // Blocks blueprint pushes for this slot
+
+  // Nothing to draw until the blueprint has pushed appearance for this session.
+  // Appearance is not persisted, so a chip stays hidden after a boot until then.
+  if (!rt.has_appearance) {
+    return;
+  }
+
+  if (visible) {
+    const bool active = (rt.last_state == SUB_STATE_ON);
+    const char *icon = active ? rt.icon_on : rt.icon_off;
+    uint16_t color = active ? rt.color_on : rt.color_off;
+
+    // An icon pushed by the blueprint wins; otherwise resolve from the domain
+    // and state, which is what the multi-state domains rely on.
+    if (icon[0] == '\0') {
+      const SubAppearance look =
+          resolve_sub_appearance(static_cast<SubDomain>(binding.domain), binding.device_class, state, rt.color_on,
+                                  rt.color_off);
+      if (look.icon != nullptr) {
+        icon = look.icon;
+        color = look.color;
+      }
+    }
+
+    if (icon[0] == '\0') {
+      ESP_LOGW(TAG, "%s has no icon, keeping it hidden", binding.component);
+      return;
+    }
+
+    if (strcmp(the_chip.icon, icon) != 0) {
+      strncpy(the_chip.icon, icon, sizeof(the_chip.icon) - 1);
+      the_chip.icon[sizeof(the_chip.icon) - 1] = '\0';
+      if (is_chips_page) {
+        nextion_display->set_component_text(CHIP_NAMES[idx], the_chip.icon);
+      }
+    }
+    if (the_chip.color != color) {
+      the_chip.color = color;
+      if (is_chips_page) {
+        nextion_display->set_component_font_color(CHIP_NAMES[idx], color);
+      }
+    }
+  }  // if visible — appearance is left untouched while hidden
+
+  if (the_chip.visible == visible) {
+    return;
+  }
+  the_chip.visible = visible;
+  if (is_chips_page) {
+    nextion_display->set_component_visibility(CHIP_NAMES[idx], visible);
+  }
+}
+
+#endif  // NSPANEL_EASY_SUBSCRIBE
 
 }  // namespace esphome::nspanel_easy
 

--- a/components/nspanel_easy/chips.cpp
+++ b/components/nspanel_easy/chips.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #ifdef NSPANEL_EASY_SUBSCRIBE
+#include "nextion_components.h"
 #include "esphome/components/nextion/nextion.h"
 #include "esphome/core/log.h"
 #endif  // NSPANEL_EASY_SUBSCRIBE

--- a/components/nspanel_easy/chips.cpp
+++ b/components/nspanel_easy/chips.cpp
@@ -47,9 +47,8 @@ void chip_sub_render(const SubBinding &binding, const SubRuntime &rt, const char
     // An icon pushed by the blueprint wins; otherwise resolve from the domain
     // and state, which is what the multi-state domains rely on.
     if (icon[0] == '\0') {
-      const SubAppearance look =
-          resolve_sub_appearance(static_cast<SubDomain>(binding.domain), binding.device_class, state, rt.color_on,
-                                  rt.color_off);
+      const SubAppearance look = resolve_sub_appearance(static_cast<SubDomain>(binding.domain), binding.device_class,
+                                                        state, rt.color_on, rt.color_off);
       if (look.icon != nullptr) {
         icon = look.icon;
         color = look.color;

--- a/components/nspanel_easy/chips.h
+++ b/components/nspanel_easy/chips.h
@@ -98,14 +98,22 @@ extern bool is_chips_page;
  * @param name Unscoped Nextion component name (e.g. "chip01").
  * @return Index into chip_states[] / CHIP_NAMES[], or UINT8_MAX if not found.
  */
-inline uint8_t find_chip_index(const std::string &name) {
+inline uint8_t find_chip_index(const char *name) {
   for (uint8_t i = 0; i < CHIP_COUNT; ++i) {
-    if (name == CHIP_NAMES[i]) {
+    if (strcmp(name, CHIP_NAMES[i]) == 0) {
       return i;
     }
   }
   return UINT8_MAX;  // sentinel: not found
 }
+
+/**
+ * @brief Find the chip index for a given component name.
+ *
+ * @param name Unscoped Nextion component name (e.g. "chip01").
+ * @return Index into chip_states[] / CHIP_NAMES[], or UINT8_MAX if not found.
+ */
+inline uint8_t find_chip_index(const std::string &name) { return find_chip_index(name.c_str()); }
 
 #ifdef NSPANEL_EASY_SUBSCRIBE
 

--- a/components/nspanel_easy/chips.h
+++ b/components/nspanel_easy/chips.h
@@ -8,6 +8,10 @@
 #include <cstring>
 #include <string>
 
+#ifdef NSPANEL_EASY_SUBSCRIBE
+#include "api_subscriptions.h"
+#endif  // NSPANEL_EASY_SUBSCRIBE
+
 /**
  * @file chips.h
  * @brief Chip state shadow for the NSPanel status chip bar.
@@ -29,6 +33,11 @@
  *   8 — chip06
  *   9 — chip07
  *
+ * Slots 0–2 are driven locally by the relay and embedded-thermostat logic and
+ * keep their own persisted appearance, so they render without Home Assistant.
+ * Slots 3–9 may be bound to a Home Assistant subscription instead, in which
+ * case blueprint pushes for them are ignored.
+ *
  * Component names are unscoped (no page prefix) so that a single write lands
  * on whichever page (home or screensaver) is currently visible.
  */
@@ -46,9 +55,10 @@ static constexpr uint8_t CHIP_COUNT = 10;
  * without requiring a new HA push.
  */
 struct ChipState {
-  char icon[4];    ///< UTF-8 MDI codepoint (1–3 bytes + null terminator)
-  uint16_t color;  ///< RGB565 foreground color
-  bool visible;    ///< Whether the chip should be shown
+  char icon[4];     ///< UTF-8 MDI codepoint (1–3 bytes + null terminator)
+  uint16_t color;   ///< RGB565 foreground color
+  bool visible;     ///< Whether the chip should be shown
+  bool subscribed;  ///< Driven by a direct HA state subscription; ignore blueprint pushes
 };
 
 /**
@@ -96,6 +106,23 @@ inline uint8_t find_chip_index(const std::string &name) {
   }
   return UINT8_MAX;  // sentinel: not found
 }
+
+#ifdef NSPANEL_EASY_SUBSCRIBE
+
+/**
+ * @brief Render a subscription binding onto a chip.
+ *
+ * Registered for the "chips" page in sub_resolve_renderer(). Receives an
+ * already-classified state and decides only how to draw it.
+ *
+ * @param binding The binding being rendered.
+ * @param rt Runtime state, including blueprint-supplied appearance.
+ * @param state Effective state string; hvac_action for climate when usable.
+ * @param visible Whether the chip should be shown.
+ */
+void chip_sub_render(const SubBinding &binding, const SubRuntime &rt, const char *state, bool visible);
+
+#endif  // NSPANEL_EASY_SUBSCRIBE
 
 }  // namespace esphome::nspanel_easy
 

--- a/components/nspanel_easy/nextion_components.cpp
+++ b/components/nspanel_easy/nextion_components.cpp
@@ -6,6 +6,8 @@
 
 namespace esphome::nspanel_easy {
 
+esphome::nextion::Nextion *nextion_display = nullptr;
+
 NSPanelEasyNextionComponent extractNextionComponent(const std::string &input, const std::string &defaultPage) {
   NSPanelEasyNextionComponent result{};
   size_t dotPos = input.find(".");

--- a/components/nspanel_easy/nextion_components.h
+++ b/components/nspanel_easy/nextion_components.h
@@ -6,7 +6,20 @@
 #include <vector>
 #include <cstdint>
 
+namespace esphome::nextion {
+class Nextion;
+}  // namespace esphome::nextion
+
 namespace esphome::nspanel_easy {
+
+/**
+ * @brief Display used by C++ outside a lambda.
+ *
+ * ESPHome declares component pointers with internal linkage in main.cpp, so
+ * they cannot be reached with extern. The pointer is assigned once from the
+ * component's to_code().
+ */
+extern esphome::nextion::Nextion *nextion_display;
 
 /**
  * @struct HMIComponent

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,8 @@ Optional packages that extend the base firmware:
 
 - [API](api.md) — custom ESPHome actions (`upload_tft`, `notification_show`,
   `rtttl_play`, `qrcode`, and more) with parameters and examples.
+- [API Subscriptions](api_subscribe.md) — drive panel components directly from
+  Home Assistant entity states, without an automation running per state change.
 - [Alarm Control Panel](alarm.md) — configure and secure alarm control from
   the panel.
 - [Customization](customization.md) — advanced examples: API encryption, custom

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,6 +5,8 @@ This document provides details on custom actions designed for integration with H
 ## Summary
 
 - [Action Documentation](#action-documentation)
+  - [API Subscribe Action (`api_subscribe`)](#api-subscribe-actions-api_subscribe): Binds a Home Assistant entity directly to a panel component, so state changes render without an automation run.
+  - [API Subscribe End Action (`api_subscribe_end`)](#api-subscribe-actions-api_subscribe): Closes a binding push and states how many bindings were sent.
   - [Button Action (`button`)](#button-action-button): Configures properties and state of buttons on a specified button page.
   - [Command Action (`command`) - DEPRECATED](#command-action-command): Sends a custom command directly to the display.
   - [Component Color Action (`component_color`)](#component-color-action-component_color): Changes the foreground color of a specified component on the display.
@@ -61,6 +63,8 @@ You can look up the action names available on your Home Assistant instance under
 <!-- markdownlint-disable MD013 -->
 | Action ID | Action Name | Description |
 | --------- | ----------- | ----------- |
+| [`api_subscribe`](#api-subscribe-actions-api_subscribe) | [API Subscribe Action](#api-subscribe-actions-api_subscribe) | Binds a Home Assistant entity directly to a panel component, so state changes render without an automation run. |
+| [`api_subscribe_end`](#api-subscribe-actions-api_subscribe) | [API Subscribe End Action](#api-subscribe-actions-api_subscribe) | Closes a binding push and states how many bindings were sent. |
 | [`button`](#button-action-button) | [Button Action](#button-action-button) | Configures properties and state of buttons on a specified button page. |
 | [`command`](#command-action-command) | [Command Action](#command-action-command) | Sends a custom command directly to the display. |
 | [`component_color`](#component-color-action-component_color) | [Component Color Action](#component-color-action-component_color) | Changes the foreground color of a specified component on the display. |
@@ -82,6 +86,20 @@ You can look up the action names available on your Home Assistant instance under
 | [`value`](#value-action-value) | [Value Action](#value-action-value) | Updates an entity to display specific values. |
 | [`wake_up`](#wake-up-action-wake_up) | [Wake Up Action](#wake-up-action-wake_up) | Activates the display from a screensaver or low-brightness state. |
 <!-- markdownlint-enable MD013 -->
+
+### API Subscribe Actions: `api_subscribe`, `api_subscribe_end`
+
+These two actions register bindings between Home Assistant entities and panel components. Once
+bound, Home Assistant streams state changes straight to the panel over the API connection and the
+panel renders them locally — no automation runs per state change.
+
+Unlike the other actions on this page, they configure an ongoing subscription rather than performing
+a one-off update, and they carry lifecycle rules that do not fit this reference format: a push
+replaces the complete set of bindings, must be closed with an end marker, and a change to any bound
+entity requires a restart to take effect.
+
+See [API Subscriptions](api_subscribe.md) for the full documentation, including parameters, state
+classification, on-device appearance resolution, and troubleshooting.
 
 ### Button Action: `button`
 
@@ -931,6 +949,7 @@ automation:
 #### User-defined Chips
 
 - **Description**: Chips are status indicator icons shown on the home page and screensaver. Their behaviour is controlled by the blueprint.
+- **Alternative**: User-defined chips can be driven directly from Home Assistant entity states instead of the blueprint. See [API Subscriptions](api_subscribe.md).
 - **Availability**: Rendered on home page and screensaver. Use `page: chips` in the `icon` action to update them from any page context.
 - **Ids**: `chip01` to `chip07`.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,7 +5,8 @@ This document provides details on custom actions designed for integration with H
 ## Summary
 
 - [Action Documentation](#action-documentation)
-  - [API Subscribe Action (`api_subscribe`)](#api-subscribe-actions-api_subscribe-api_subscribe_end): Binds a Home Assistant entity directly to a panel component, so state changes render without an automation run.
+  - [API Subscribe Action (`api_subscribe`)](#api-subscribe-actions-api_subscribe-api_subscribe_end):
+    Binds a Home Assistant entity directly to a panel component, so state changes render without an automation run.
   - [API Subscribe End Action (`api_subscribe_end`)](#api-subscribe-actions-api_subscribe-api_subscribe_end): Closes a binding push and states how many bindings were sent.
   - [Button Action (`button`)](#button-action-button): Configures properties and state of buttons on a specified button page.
   - [Command Action (`command`) - DEPRECATED](#command-action-command): Sends a custom command directly to the display.

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,8 +5,8 @@ This document provides details on custom actions designed for integration with H
 ## Summary
 
 - [Action Documentation](#action-documentation)
-  - [API Subscribe Action (`api_subscribe`)](#api-subscribe-actions-api_subscribe): Binds a Home Assistant entity directly to a panel component, so state changes render without an automation run.
-  - [API Subscribe End Action (`api_subscribe_end`)](#api-subscribe-actions-api_subscribe): Closes a binding push and states how many bindings were sent.
+  - [API Subscribe Action (`api_subscribe`)](#api-subscribe-actions-api_subscribe-api_subscribe_end): Binds a Home Assistant entity directly to a panel component, so state changes render without an automation run.
+  - [API Subscribe End Action (`api_subscribe_end`)](#api-subscribe-actions-api_subscribe-api_subscribe_end): Closes a binding push and states how many bindings were sent.
   - [Button Action (`button`)](#button-action-button): Configures properties and state of buttons on a specified button page.
   - [Command Action (`command`) - DEPRECATED](#command-action-command): Sends a custom command directly to the display.
   - [Component Color Action (`component_color`)](#component-color-action-component_color): Changes the foreground color of a specified component on the display.
@@ -63,8 +63,8 @@ You can look up the action names available on your Home Assistant instance under
 <!-- markdownlint-disable MD013 -->
 | Action ID | Action Name | Description |
 | --------- | ----------- | ----------- |
-| [`api_subscribe`](#api-subscribe-actions-api_subscribe) | [API Subscribe Action](#api-subscribe-actions-api_subscribe) | Binds a Home Assistant entity directly to a panel component, so state changes render without an automation run. |
-| [`api_subscribe_end`](#api-subscribe-actions-api_subscribe) | [API Subscribe End Action](#api-subscribe-actions-api_subscribe) | Closes a binding push and states how many bindings were sent. |
+| [`api_subscribe`](#api-subscribe-actions-api_subscribe-api_subscribe_end) | [API Subscribe Action](#api-subscribe-actions-api_subscribe-api_subscribe_end) | Binds a Home Assistant entity directly to a panel component, so state changes render without an automation run. |
+| [`api_subscribe_end`](#api-subscribe-actions-api_subscribe-api_subscribe_end) | [API Subscribe End Action](#api-subscribe-actions-api_subscribe-api_subscribe_end) | Closes a binding push and states how many bindings were sent. |
 | [`button`](#button-action-button) | [Button Action](#button-action-button) | Configures properties and state of buttons on a specified button page. |
 | [`command`](#command-action-command) | [Command Action](#command-action-command) | Sends a custom command directly to the display. |
 | [`component_color`](#component-color-action-component_color) | [Component Color Action](#component-color-action-component_color) | Changes the foreground color of a specified component on the display. |

--- a/docs/api_subscribe.md
+++ b/docs/api_subscribe.md
@@ -1,0 +1,325 @@
+# API Subscriptions
+
+The API subscription engine lets the panel receive Home Assistant entity states directly over the
+ESPHome API, instead of having an automation react to every state change and push the result to the
+panel.
+
+The Blueprint still decides *which* entity drives *which* component. Once that is registered, Home
+Assistant streams state changes straight to the panel, and the panel renders them locally — no
+automation run, no trace, no logbook entry.
+
+## Summary
+
+- [Why this exists](#why-this-exists)
+- [How it works](#how-it-works)
+- [Enabling the engine](#enabling-the-engine)
+- [Action reference](#action-reference)
+  - [`api_subscribe`](#api_subscribe)
+  - [`api_subscribe_end`](#api_subscribe_end)
+- [Driving the panel without the Blueprint](#driving-the-panel-without-the-blueprint)
+- [State classification](#state-classification)
+- [Appearance resolution](#appearance-resolution)
+- [Limits and behaviour](#limits-and-behaviour)
+- [Troubleshooting](#troubleshooting)
+
+## Why this exists
+
+Without subscriptions, every state change of every entity shown on the panel triggers the Blueprint
+automation. On a panel with a busy motion sensor and a handful of lights, that is thousands of
+automation runs per day, each one producing a trace and competing with everything else Home
+Assistant is doing.
+
+With subscriptions, Home Assistant pushes the raw state string to the panel over the existing API
+connection. The panel classifies it, resolves the icon and colour, and writes to the display. The
+automation runs once per session, not once per state change.
+
+## How it works
+
+### Bindings
+
+A **binding** connects one Home Assistant entity to one panel component. It consists of:
+
+| Field | Purpose |
+| --- | --- |
+| `page` | Which page the target component belongs to, e.g. `chips` |
+| `component` | Which component on that page, e.g. `chip01` |
+| `entity` | The Home Assistant `entity_id` to follow |
+| `device_class` | Used only for the `cover` domain, to pick the right icon set |
+| `inverted` | Render the component as visible while the entity is inactive |
+
+Bindings are stored in the panel's NVS partition. Appearance — icons and colours — is **not**
+stored, and arrives with every push.
+
+### Lifecycle
+
+1. **Boot.** Before the API connects, the panel loads its persisted bindings and registers one
+   Home Assistant state subscription per binding. Climate bindings register a second subscription
+   for the `hvac_action` attribute.
+2. **Connect.** Home Assistant delivers the current state of every subscribed entity immediately.
+   The panel classifies and renders each one.
+3. **Push.** The Blueprint sends one `api_subscribe` call per component, then closes with
+   `api_subscribe_end` carrying how many it sent. Appearance is applied immediately; entity
+   bindings are staged.
+4. **Commit.** If the staged set differs from the persisted one, the panel saves it and restarts.
+   If it matches, nothing happens — which is the normal case on every reconnect.
+5. **Steady state.** Home Assistant pushes state changes. The panel renders them. No automation
+   runs.
+
+### Why a restart is required
+
+ESPHome only sends subscription requests to Home Assistant during the burst that follows the
+initial `SubscribeHomeAssistantStatesRequest`. Once that burst drains, `APIConnection` stops
+sending, and a subscription registered later is stored but never transmitted.
+
+The Blueprint can only push bindings *after* the API is connected, which is always after that burst
+has drained. A new binding therefore cannot take effect in the session that registered it. The
+panel persists the binding and restarts, so the next boot registers it in time.
+
+This is a limitation of ESPHome, not a design choice. If ESPHome gains runtime subscriptions, both
+the persistence layer and the restart become unnecessary.
+
+## Enabling the engine
+
+Add the package to your device YAML:
+
+```yaml
+packages:
+  nspanel_easy:
+    url: https://github.com/edwardtfn/NSPanel-Easy/
+    ref: main
+    files:
+      - esphome/nspanel_esphome.yaml
+      - esphome/nspanel_esphome_api_subscribe.yaml
+    refresh: 300s
+```
+
+The package enables `api: homeassistant_states: true` automatically, which is required —
+`subscribe_home_assistant_state()` does not exist without it.
+
+### Options
+
+| Substitution | Default | Description |
+| --- | --- | --- |
+| `api_subscribe_max` | `128` | Maximum number of bindings. Storage is allocated to the configured count, not to this limit. |
+| `api_subscribe_debounce` | `10s` | Quiet period after the last binding before a restart is applied. |
+| `api_subscribe_timeout` | `120s` | Time without an end marker before the push is committed unverified. |
+
+Lowering `api_subscribe_max` reduces the size of the staging buffer used during a push. It does not
+reduce steady-state memory, which scales with the number of bindings actually configured.
+
+## Action reference
+
+### `api_subscribe`
+
+Registers one binding. Called once per subscribable component.
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `page` | string | Target page. Currently only `chips` has a renderer. |
+| `component` | string | Target component, e.g. `chip01`. |
+| `entity` | string | Home Assistant `entity_id`. |
+| `device_class` | string | HA `device_class`. Only read for the `cover` domain; send an empty string otherwise. |
+| `icon_on` | string | Icon codepoint for the active state. Empty resolves on-device. |
+| `icon_off` | string | Icon codepoint for the inactive state. Empty resolves on-device. |
+| `color_on` | int[] | RGB array for the active state, e.g. `[200, 204, 200]`. |
+| `color_off` | int[] | RGB array for the inactive state. |
+| `inverted` | bool | Render the component as visible while the entity is inactive. |
+
+```yaml
+action: esphome.my_panel_api_subscribe
+data:
+  page: chips
+  component: chip01
+  entity: binary_sensor.corridor_motion
+  device_class: ""
+  icon_on: "\uE1B1"
+  icon_off: ""
+  color_on: [255, 193, 7]
+  color_off: [92, 92, 92]
+  inverted: false
+```
+
+> [!IMPORTANT]
+> A push replaces the complete set of bindings. Any component not included is unsubscribed.
+> Calling `api_subscribe` on its own, outside a full push, will replace every existing binding.
+
+### `api_subscribe_end`
+
+Closes the push and states how many bindings were sent.
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `count` | int | Number of `api_subscribe` calls made in this push. |
+
+```yaml
+action: esphome.my_panel_api_subscribe_end
+data:
+  count: 7
+```
+
+If the count does not match what the panel received, the push is discarded and the previously
+persisted bindings stay in effect. This prevents a truncated push from silently wiping bindings.
+
+## Driving the panel without the Blueprint
+
+The engine has no dependency on the Blueprint. Any automation, script, or external integration that
+can call ESPHome actions can register bindings.
+
+A minimal Home Assistant script that binds two chips:
+
+```yaml
+alias: NSPanel chips
+sequence:
+  - action: esphome.my_panel_api_subscribe
+    data:
+      page: chips
+      component: chip01
+      entity: binary_sensor.front_door
+      device_class: ""
+      icon_on: "\uE18D"
+      icon_off: "\uE18C"
+      color_on: [255, 0, 0]
+      color_off: [92, 92, 92]
+      inverted: false
+  - action: esphome.my_panel_api_subscribe
+    data:
+      page: chips
+      component: chip02
+      entity: cover.garage_door
+      device_class: garage
+      icon_on: ""
+      icon_off: ""
+      color_on: [200, 204, 200]
+      color_off: [92, 92, 92]
+      inverted: false
+  - action: esphome.my_panel_api_subscribe_end
+    data:
+      count: 2
+mode: single
+```
+
+Trigger it on `homeassistant_start` and on the panel's boot announcement, and the panel is fully
+configured without the Blueprint.
+
+### Resolving icons yourself
+
+For domains where the appearance is the same across every visible state, the panel expects you to
+supply `icon_on` and `icon_off`. Two rules matter:
+
+- Resolve the icon for the state in which the component will be **shown**, not for the entity's
+  current state. A motion sensor that happens to be idle when you push would otherwise freeze the
+  "no motion" icon onto a chip that only ever appears when motion is detected.
+- Send the codepoint, not the `mdi:` name. The
+  [MDI Icons Cheatsheet](https://edwardtfn.github.io/NSPanel-Easy/icons/cheatsheet.html) lists
+  every supported icon.
+
+For `alarm_control_panel`, `climate`, `cover`, `lock` and `water_heater`, leave both icon fields
+empty and the panel resolves them from the domain and state. See
+[Appearance resolution](#appearance-resolution).
+
+## State classification
+
+Every incoming state is classified into one of four categories, and visibility follows from the
+category and the `inverted` flag.
+
+| Category | Not inverted | Inverted |
+| --- | --- | --- |
+| Active | Visible | Hidden |
+| Inactive | Hidden | Visible |
+| Transitional | Visible | Visible |
+| Unrecognised | Hidden | Hidden |
+
+Transitional states are shown in both polarities so that movement is always surfaced. A garage door
+chip shows an amber arrow for the whole travel, regardless of how it is configured.
+
+Unrecognised states — including `unavailable`, `unknown` and `none` — hide the component in both
+polarities. An entity that drops off the network never lights an inverted component by accident.
+
+### Per-domain states
+
+| Domain | Active | Transitional | Inactive |
+| --- | --- | --- | --- |
+| `alarm_control_panel` | `armed_home`, `armed_away`, `armed_night`, `armed_vacation`, `armed_custom_bypass`, `triggered` | `arming`, `pending`, `disarming` | `disarmed` |
+| `climate` | `heat`, `heating`, `cool`, `cooling`, `heat_cool`, `dry`, `drying`, `fan`, `fan_only`, `auto` | — | `off`, `idle` |
+| `cover` | `open` | `opening`, `closing` | `closed` |
+| `lock` | `unlocked`, `open`, `jammed` | `locking`, `unlocking`, `opening` | `locked` |
+| `water_heater` | `on`, `eco`, `electric`, `gas`, `heat_pump`, `high_demand`, `performance` | — | `off` |
+| everything else | `on`, `true`, `1`, `active`, `home`, `playing` | — | `off`, `false`, `0`, `not_home`, `idle`, `standby`, `paused` |
+
+`climate` bindings subscribe to both the state and the `hvac_action` attribute. When `hvac_action`
+holds a usable value it takes precedence, so a thermostat set to `heat` but currently idle is
+classified as inactive.
+
+## Appearance resolution
+
+For five domains the icon and colour change across the visible state set, so the panel resolves
+them locally. Send empty icon fields to use this.
+
+| Domain | Resolved from |
+| --- | --- |
+| `alarm_control_panel` | State — a distinct shield icon and colour per armed, transitional and disarmed state |
+| `climate` | `hvac_action` when usable, otherwise the hvac mode |
+| `cover` | `device_class` and state — thirteen device classes, each with open, opening, closed and closing icons |
+| `lock` | State — locked, unlocked and transitional |
+| `water_heater` | Operation mode |
+
+Sending a non-empty `icon_on` or `icon_off` overrides resolution for that state, which is how a user
+icon override reaches the panel.
+
+Covers with no `device_class`, or with one the panel does not recognise, fall back to a generic
+blinds icon in all four states.
+
+## Limits and behaviour
+
+- **Only `chips` has a renderer today.** Bindings for other pages are accepted, persisted and
+  subscribed, but nothing is drawn and `dump_config` marks them `[no renderer]`.
+- **`chip_relay1`, `chip_relay2` and `chip_climate` cannot be bound.** They are driven locally by
+  the relay and embedded-thermostat logic and keep working without Home Assistant. Attempting to
+  bind them logs a warning and is ignored.
+- **Components stay hidden after a boot until the Blueprint reconnects.** Appearance is not
+  persisted, so the panel knows a chip's state before it knows what to draw.
+- **A binding change costs one restart.** Appearance changes, inversion changes and repeated
+  identical pushes do not.
+- **The panel refuses to commit unverified pushes indefinitely.** After three consecutive pushes
+  with no end marker, the panel keeps its last good set and logs an error rather than restarting in
+  a loop.
+- **Numeric sensors are not classified.** A `sensor` state such as `23.4` matches neither the active
+  nor inactive list, so the component stays hidden. Sensor values are not yet supported by this
+  engine.
+
+## Troubleshooting
+
+### Nothing renders after binding
+
+Check `dump_config` for the loaded bindings:
+
+```text
+[C][nspanel.sub]: Subscriptions
+[C][nspanel.sub]:   Bindings: 2 of 128
+[C][nspanel.sub]:   chips.chip01 <- binary_sensor.front_door
+[C][nspanel.sub]:   chips.chip02 <- cover.garage_door
+```
+
+If bindings are listed but nothing draws, the Blueprint has not pushed appearance in this session.
+Reload the automation.
+
+If a binding shows `[no renderer]`, the target page has no renderer — see
+[Limits and behaviour](#limits-and-behaviour).
+
+### The panel restarts on every reconnect
+
+The staged set is differing from the persisted one every time. Usually the Blueprint is sending
+bindings in a different order between pushes, or a `device_class` is being sent for a non-cover
+entity in one push and not another. Both count as a change.
+
+### `Push incomplete` in the log
+
+The end marker's count did not match how many bindings arrived. The push was discarded and the
+previous bindings are still in effect. Check whether any `api_subscribe` call is failing validation
+— an entity_id longer than 63 characters is rejected.
+
+### `refusing to commit` in the log
+
+Three consecutive pushes arrived without an end marker. Verify that the automation is calling
+`api_subscribe_end` after the last binding. The panel keeps running its last good set until this is
+resolved.

--- a/docs/api_subscribe.md
+++ b/docs/api_subscribe.md
@@ -55,8 +55,9 @@ stored, and arrives with every push.
 1. **Boot.** Before the API connects, the panel loads its persisted bindings and registers one
    Home Assistant state subscription per binding. Climate bindings register a second subscription
    for the `hvac_action` attribute.
-2. **Connect.** Home Assistant delivers the current state of every subscribed entity immediately.
-   The panel classifies and renders each one.
+2. **Connect.** Home Assistant delivers the current state of every subscribed
+   entity immediately. The panel classifies each state, and renders once a
+   binding push has supplied appearance.
 3. **Push.** The Blueprint sends one `api_subscribe` call per component, then closes with
    `api_subscribe_end` carrying how many it sent. Appearance is applied immediately; entity
    bindings are staged.
@@ -276,8 +277,9 @@ blinds icon in all four states.
 - **`chip_relay1`, `chip_relay2` and `chip_climate` cannot be bound.** They are driven locally by
   the relay and embedded-thermostat logic and keep working without Home Assistant. Attempting to
   bind them logs a warning and is ignored.
-- **Components stay hidden after a boot until the Blueprint reconnects.** Appearance is not
-  persisted, so the panel knows a chip's state before it knows what to draw.
+- **Components stay hidden after a boot until a binding push arrives.**
+  Appearance is not persisted, so the panel knows a component's state before it
+  knows what to draw.
 - **A binding change costs one restart.** Appearance changes, inversion changes and repeated
   identical pushes do not.
 - **The panel refuses to commit unverified pushes indefinitely.** After three consecutive pushes
@@ -300,8 +302,9 @@ Check `dump_config` for the loaded bindings:
 [C][nspanel.sub]:   chips.chip02 <- cover.garage_door
 ```
 
-If bindings are listed but nothing draws, the Blueprint has not pushed appearance in this session.
-Reload the automation.
+If bindings are listed but nothing draws, no binding push has supplied
+appearance in this session. Reload the automation, or re-run whatever registers
+your bindings.
 
 If a binding shows `[no renderer]`, the target page has no renderer — see
 [Limits and behaviour](#limits-and-behaviour).

--- a/esphome/nspanel_esphome_api.yaml
+++ b/esphome/nspanel_esphome_api.yaml
@@ -14,6 +14,12 @@ substitutions:
   TAG_API: nspanel.api
   EVENT_NAME: esphome.nspanel_easy
 
+
+packages:
+  # yamllint disable rule:colons
+  api_subscribe: !include nspanel_esphome_api_subscribe.yaml
+  # yamllint enable rule:colons
+
 api:
   id: api_server
   homeassistant_services: true

--- a/esphome/nspanel_esphome_api_subscribe.yaml
+++ b/esphome/nspanel_esphome_api_subscribe.yaml
@@ -1,0 +1,118 @@
+#####################################################################################################
+#####                 NSPanel Easy - https://github.com/edwardtfn/NSPanel-Easy                  #####
+#####################################################################################################
+##### ESPHOME CORE - HOME ASSISTANT STATE SUBSCRIPTIONS (EXPERIMENTAL)                          #####
+##### PLEASE only make changes if it is necessary and also the required knowledge is available. #####
+##### For normal use with the Blueprint, no changes are necessary.                              #####
+#####                                                                                           #####
+##### The blueprint pushes a set of bindings once per session, closing with subscribe_end.      #####
+##### ESPHome persists them and re-subscribes on every boot, so state changes render locally    #####
+##### without an automation run.                                                                #####
+#####                                                                                           #####
+##### Bindings take effect on the following boot: APIConnection latches state_subs_at_ to -1    #####
+##### once the initial burst drains, and the blueprint can only push after the API is           #####
+##### connected. A binding change therefore schedules a restart. Should ESPHome gain runtime    #####
+##### subscriptions, both the persistence layer and the restart can be removed.                 #####
+#####################################################################################################
+---
+substitutions:
+  TAG_SUB: nspanel.sub
+  ##### Maximum number of bindings. Storage is allocated to the configured count, not this. #####
+  subscribe_max: '128'
+  ##### Seconds of quiet after the last binding before a restart is applied. #####
+  subscribe_debounce: '10s'
+  ##### Seconds without an end marker before committing the push unverified. #####
+  subscribe_timeout: '120s'
+
+esphome:
+  build_flags:
+    - -D NSPANEL_EASY_SUBSCRIBE
+    - -D NSPANEL_EASY_SUB_MAX=${subscribe_max}
+
+api:
+  homeassistant_states: true  # Required: enables USE_API_HOMEASSISTANT_STATES
+  actions:
+    ##### One binding. The blueprint sends one call per subscribable component. #####
+    - action: api_subscribe
+      variables:
+        page: string          # Target page, e.g. "chips"
+        component: string     # Target component, e.g. "chip01"
+        entity: string        # Home Assistant entity_id
+        device_class: string  # HA device_class; only consulted for the cover domain
+        icon_on: string       # Icon for the active state; empty to resolve on-device
+        icon_off: string      # Icon for the inactive state; empty to resolve on-device
+        color_on: int[]       # RGB array for the active state
+        color_off: int[]      # RGB array for the inactive state
+        inverted: bool        # Render as visible while the entity is inactive
+      then:
+        - lambda: |-
+            sub_push_binding(page.c_str(), component.c_str(), entity.c_str(), device_class.c_str(),
+                              icon_on.c_str(), icon_off.c_str(),
+                              color_on.size() == 3 ? rgbTo565(color_on) : 0,
+                              color_off.size() == 3 ? rgbTo565(color_off) : 0, inverted);
+        - script.execute: subscribe_debounce
+        - script.execute: subscribe_watchdog
+
+    ##### End marker. Sent after every binding, carrying how many were sent. #####
+    - action: api_subscribe_end
+      variables:
+        count: int
+      then:
+        - lambda: |-
+            if (sub_push_end(static_cast<uint16_t>(count))) {
+              subscribe_restart->execute();
+            }
+        - script.stop: subscribe_watchdog
+
+script:
+  ##### Collapses a burst of binding calls into a single restart decision. #####
+  - id: subscribe_debounce
+    mode: restart
+    then:
+      - delay: ${subscribe_debounce}
+
+  ##### Safety net for a push whose end marker never arrives. #####
+  - id: subscribe_watchdog
+    mode: restart
+    then:
+      - delay: ${subscribe_timeout}
+      - lambda: |-
+          if (sub_push_timeout()) {
+            subscribe_restart->execute();
+          }
+
+  ##### Waits for the push to go quiet, then restarts to activate the bindings. #####
+  - id: subscribe_restart
+    mode: restart
+    then:
+      - wait_until:
+          condition:
+            not:
+              script.is_running: subscribe_debounce
+      - lambda: |-
+          ESP_LOGI("${TAG_SUB}", "Restarting to activate new binding(s)");
+      - delay: 250ms
+      - lambda: |-
+          App.safe_reboot();
+
+  - id: !extend boot_early_routines
+    then:
+      - lambda: |-
+          // Must run before the API connects: a subscription registered after
+          // the initial burst is stored by ESPHome and never sent.
+          if (sub_load() > 0) {
+            sub_subscribe_all();
+          }
+
+  - id: !extend page_change
+    then:
+      - lambda: |-
+          // Re-render bound components from their last known state, so a page
+          // change does not need a round trip to Home Assistant.
+          sub_render_all();
+
+  - id: !extend dump_config
+    then:
+      - lambda: |-
+          sub_dump_config();
+...

--- a/esphome/nspanel_esphome_chips.yaml
+++ b/esphome/nspanel_esphome_chips.yaml
@@ -19,7 +19,6 @@ esphome:
     - -D NSPANEL_EASY_CHIPS_PAGE_HOME=${1 if chips_page_home else 0}
     - -D NSPANEL_EASY_CHIPS_PAGE_SCREENSAVER=${1 if chips_page_screensaver else 0}
 
-
 globals:
   # Font ID used for all chip icons. Persisted so relay chips can render
   # correctly before the blueprint reconnects after a reboot.
@@ -97,6 +96,7 @@ script:
           if (idx == UINT8_MAX) return;
 
           ChipState &the_chip = chip_states[idx];
+          if (the_chip.subscribed) return;  // Driven directly by a HA state subscription
           if (the_chip.color == color) return;
 
           the_chip.color = color;
@@ -112,6 +112,7 @@ script:
           if (idx == UINT8_MAX) return;
 
           ChipState &the_chip = chip_states[idx];
+          if (the_chip.subscribed) return;  // Driven directly by a HA state subscription
           if (strcmp(the_chip.icon, txt.c_str()) == 0) return;
 
           strncpy(the_chip.icon, txt.c_str(), sizeof(the_chip.icon) - 1);
@@ -126,6 +127,8 @@ script:
 
           const uint8_t idx = find_chip_index(component);
           if (idx == UINT8_MAX) return;
+
+          if (chip_states[idx].subscribed) return;  // Driven directly by a HA state subscription
 
           if (chip_states[idx].visible != visible) {
             chip_states[idx].visible = visible;

--- a/esphome/nspanel_esphome_chips.yaml
+++ b/esphome/nspanel_esphome_chips.yaml
@@ -39,6 +39,7 @@ script:
 
           // Update shadow state
           ChipState &the_chip = chip_states[idx];
+          if (the_chip.subscribed) return;  // Driven directly by a HA state subscription
 
           // Render immediately if on a supported page (full render — icon+color just updated)
           if (strcmp(the_chip.icon, icon.c_str()) != 0) {

--- a/esphome/nspanel_esphome_hw_display.yaml
+++ b/esphome/nspanel_esphome_hw_display.yaml
@@ -130,6 +130,9 @@ globals:
     restore_value: false
     initial_value: 'false'
 
+nspanel_easy:
+  nextion_id: disp1
+
 number:
   - id: display_brightness  # Screen brightness when in use
     name: Display Brightness

--- a/esphome/nspanel_esphome_standard.yaml
+++ b/esphome/nspanel_esphome_standard.yaml
@@ -15,7 +15,7 @@ esphome:
 
 packages:
   # yamllint disable rule:colons
-  -hw_buzzer:         !include nspanel_esphome_hw_buzzer.yaml
+  hw_buzzer:         !include nspanel_esphome_hw_buzzer.yaml
   hw_relays:         !include nspanel_esphome_hw_relays.yaml
   hw_temperature:    !include nspanel_esphome_hw_temperature.yaml
   page_alarm:        !include nspanel_esphome_page_alarm.yaml

--- a/esphome/nspanel_esphome_version.yaml
+++ b/esphome/nspanel_esphome_version.yaml
@@ -14,7 +14,7 @@ substitutions:
   # Minimum required blueprint version for compatibility
   # Select 'next' or '${version}' when you change the "contract" between ESPHome and Blueprint
   # Versioning workflow will replace this by the new version being generated
-  min_blueprint_version: 2026.5.15
+  min_blueprint_version: ${version}
 
   # Minimum required TFT version for compatibility
   # Must be manually updated with Nextion Editor

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -7039,6 +7039,7 @@ actions:
                                   | selectattr("entity", "defined")
                                   | selectattr("entity", "string")
                                   | rejectattr("entity", "eq", "")
+                                  | selectattr("entity", "search", "^[^.]+\\.[^.]+$")
                                   | list
                                 }}
 
@@ -7116,12 +7117,7 @@ actions:
 
                               - action: 'esphome.{{ action_prefix }}_api_subscribe_end'
                                 data:
-                                  count: >
-                                    {{
-                                      api_subscriptions
-                                      | selectattr("entity", "search", "\\.")
-                                      | list | count
-                                    }}
+                                  count: '{{ api_subscriptions | count }}'
                                 continue_on_error: true
 
                       - &variables_hardware

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -7083,8 +7083,10 @@ actions:
                                             ["alarm_control_panel", "climate", "cover", "lock", "water_heater"]
                                           }}
 
-                                    # Resolve the icon for the state in which the
-                                    # component is shown, not for the current state.
+                                    # A chip is only ever visible in one state, so its
+                                    # icon must be resolved for that state rather than
+                                    # for whatever the entity happens to be doing now.
+                                    # Resolve both, and let the panel pick.
                                     - variables:
                                         forced_icon_state: 'on'
                                     - *variable_entity

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -6,7 +6,7 @@
 ##################################################################################################
 ---
 blueprint:
-  name: NSPanel Easy Configuration (v2026.8.3)
+  name: NSPanel Easy Configuration (v9999.99.9)
   author: Edward Firmo (https://github.com/edwardtfn)
   description: >
     # NSPanel Easy Configuration via Blueprint
@@ -4650,7 +4650,7 @@ trigger_variables:
 
 variables:
   # Version will be following release version defined automatically when merging to main
-  blueprint_version: 2026.8.3
+  blueprint_version: 9999.99.9
 
   pages:
     current: '{{ states(currentpage) }}'
@@ -8662,6 +8662,7 @@ actions:
                                   entity_domain_is_light and
                                   (
                                     supported_features | bitwise_and(1) > 0 or
+                                    "brightness" in states[entity_id].attributes or
                                     enum.ColorMode.BRIGHTNESS in supported_color_modes or
                                     "brightness" in supported_color_modes or
                                     supported_color_modes

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -8640,13 +8640,13 @@ actions:
                                   entity_domain_is_light and
                                   (
                                     supported_features | bitwise_and(1) > 0 or
-                                    "brightness" in states[entity_id].attributes or
                                     enum.ColorMode.BRIGHTNESS in supported_color_modes or
                                     "brightness" in supported_color_modes or
                                     supported_color_modes
                                       | map(attribute="value") | list
                                       | select("in", ["brightness"])
                                       | list | length > 0 or
+                                    state_attr(entity_id, "brightness") is not none or
                                     state_attr(entity_id, "brightness") | int(-1) >= 0
                                   )
                                 }}

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -5227,42 +5227,6 @@ triggers:
         trigger: state
         entity_id: !input entities_entity32
 
-  - triggers:  # Home page - Chips
-      - alias: Chip 01
-        id: trigger_chip_state
-        trigger: state
-        entity_id: !input chip01
-
-      - alias: Chip 02
-        id: trigger_chip_state
-        trigger: state
-        entity_id: !input chip02
-
-      - alias: Chip 03
-        id: trigger_chip_state
-        trigger: state
-        entity_id: !input chip03
-
-      - alias: Chip 04
-        id: trigger_chip_state
-        trigger: state
-        entity_id: !input chip04
-
-      - alias: Chip 05
-        id: trigger_chip_state
-        trigger: state
-        entity_id: !input chip05
-
-      - alias: Chip 06
-        id: trigger_chip_state
-        trigger: state
-        entity_id: !input chip06
-
-      - alias: Chip 07
-        id: trigger_chip_state
-        trigger: state
-        entity_id: !input chip07
-
   - triggers:  # Home page - Values
       - alias: Value 01
         id: home_values_state
@@ -5699,12 +5663,6 @@ conditions:
     }}
   - >  # Update page Home only when visible or home_page_background_update is enabled
     {{ trigger.id not in ["home_values_state"] or home_page_background_update or pages.current == pages.home }}
-  - >  # Update page Home only when visible or home_page_background_update is enabled
-    {{
-      trigger.id not in ["trigger_chip_state"] or
-      home_page_background_update or
-      pages.current in [ pages.home, pages.screensaver ]
-    }}
   - >  # Do not update values when page utilities is not visible
     {{ trigger.id != "utilities_page" or pages.current == pages.utilities }}
   - >  # Do not update values when page entities is not visible
@@ -6001,44 +5959,6 @@ actions:
             label_color_rgb: !input home_value04_label_color
             page: home
             component: value04
-
-      ##### Chips #####
-      chips:
-        - entity: !input chip01
-          inverted: !input chip01_inverted
-          icon: !input chip01_icon
-          icon_color_rgb: !input chip01_icon_color
-          component: chip01
-        - entity: !input chip02
-          inverted: !input chip02_inverted
-          icon: !input chip02_icon
-          icon_color_rgb: !input chip02_icon_color
-          component: chip02
-        - entity: !input chip03
-          inverted: !input chip03_inverted
-          icon: !input chip03_icon
-          icon_color_rgb: !input chip03_icon_color
-          component: chip03
-        - entity: !input chip04
-          inverted: !input chip04_inverted
-          icon: !input chip04_icon
-          icon_color_rgb: !input chip04_icon_color
-          component: chip04
-        - entity: !input chip05
-          inverted: !input chip05_inverted
-          icon: !input chip05_icon
-          icon_color_rgb: !input chip05_icon_color
-          component: chip05
-        - entity: !input chip06
-          inverted: !input chip06_inverted
-          icon: !input chip06_icon
-          icon_color_rgb: !input chip06_icon_color
-          component: chip06
-        - entity: !input chip07
-          inverted: !input chip07_inverted
-          icon: !input chip07_icon
-          icon_color_rgb: !input chip07_icon_color
-          component: chip07
 
       ##### Button pages #####
       buttons_pages:
@@ -6747,6 +6667,7 @@ actions:
           milliseconds: !input delay
       - variables:
           entity_id: '{{ None }}'
+          forced_icon_state: '{{ None }}'
           overlap:
             icon: '{{ None }}'
             icon_color: '{{ None }}'
@@ -6777,6 +6698,7 @@ actions:
           entity_has_value: '{{ has_value(entity_id) if entity_id_valid }}'
           entity_domain: '{{ states[entity_id].domain if entity_id_valid }}'
           entity_icon: '{{ state_attr(entity_id, "icon") | default("") if entity_id_valid }}'
+          icon_state: '{{ forced_icon_state | default(entity_state, true) }}'
           entity_icon_valid: >
             {{
               entity_icon is defined and
@@ -6977,7 +6899,7 @@ actions:
                 {%- elif entity_device_class is string and
                     entity_device_class | length > 0 and
                     entity_domain in device_class_icons -%}
-                  {%- set state_suffix = "" if entity_domain in ["button", "event", "sensor"] else ("-" + entity_state) -%}
+                  {%- set state_suffix = "" if entity_domain in ["button", "event", "sensor"] else ("-" + icon_state) -%}
                   {%- set device_class_key = entity_device_class + state_suffix -%}
                   {%- if device_class_key in device_class_icons[entity_domain] -%}
                     {{ all_icons[device_class_icons[entity_domain][device_class_key]] }}
@@ -7058,6 +6980,147 @@ actions:
 
                       # Stop here if this is initial boot as Nextion may not be ready
                       - condition: '{{ global_settings_setup }}'
+
+                      - alias: API Subscriptions
+                        sequence:
+                          - variables:
+                              api_subs_mapping:
+                                ##### Chips #####
+                                - entity: !input chip01
+                                  inverted: !input chip01_inverted
+                                  icon: !input chip01_icon
+                                  icon_color_rgb: !input chip01_icon_color
+                                  page: chips
+                                  component: chip01
+                                - entity: !input chip02
+                                  inverted: !input chip02_inverted
+                                  icon: !input chip02_icon
+                                  icon_color_rgb: !input chip02_icon_color
+                                  page: chips
+                                  component: chip02
+                                - entity: !input chip03
+                                  inverted: !input chip03_inverted
+                                  icon: !input chip03_icon
+                                  icon_color_rgb: !input chip03_icon_color
+                                  page: chips
+                                  component: chip03
+                                - entity: !input chip04
+                                  inverted: !input chip04_inverted
+                                  icon: !input chip04_icon
+                                  icon_color_rgb: !input chip04_icon_color
+                                  page: chips
+                                  component: chip04
+                                - entity: !input chip05
+                                  inverted: !input chip05_inverted
+                                  icon: !input chip05_icon
+                                  icon_color_rgb: !input chip05_icon_color
+                                  page: chips
+                                  component: chip05
+                                - entity: !input chip06
+                                  inverted: !input chip06_inverted
+                                  icon: !input chip06_icon
+                                  icon_color_rgb: !input chip06_icon_color
+                                  page: chips
+                                  component: chip06
+                                - entity: !input chip07
+                                  inverted: !input chip07_inverted
+                                  icon: !input chip07_icon
+                                  icon_color_rgb: !input chip07_icon_color
+                                  page: chips
+                                  component: chip07
+
+                              ##### API subscriptions #####
+                              # Components driven directly by ESPHome through Home Assistant state
+                              # subscriptions. The panel renders these locally, so this automation does
+                              # not trigger on their entities at all.
+                              api_subscriptions: >
+                                {{
+                                  api_subs_mapping
+                                  | selectattr("entity", "defined")
+                                  | selectattr("entity", "string")
+                                  | rejectattr("entity", "eq", "")
+                                  | list
+                                }}
+
+                          ###### API subscriptions ######
+                          - &push_subscriptions
+                            alias: Push API subscriptions
+                            sequence:
+                              - repeat:
+                                  for_each: '{{ api_subscriptions }}'
+                                  sequence:
+                                    - condition: '{{ repeat.item.entity.split(".") | count == 2 }}'
+                                    - variables:
+                                        entity_id: '{{ repeat.item.entity }}'
+                                        icon_color_rgb_valid: >
+                                          {{
+                                            repeat.item.icon_color_rgb is defined and
+                                            repeat.item.icon_color_rgb is list and
+                                            repeat.item.icon_color_rgb | count == 3
+                                          }}
+                                        overlap:
+                                          icon: >
+                                            {{
+                                              repeat.item.icon
+                                              if
+                                                repeat.item.icon is defined and
+                                                repeat.item.icon is string and
+                                                repeat.item.icon | length > 0 and
+                                                repeat.item.icon is match "mdi:" and
+                                                repeat.item.icon.split("mdi:")[1] in all_icons
+                                              else
+                                                None
+                                            }}
+                                          icon_color: '{{ repeat.item.icon_color_rgb if icon_color_rgb_valid else None }}'
+
+                                    # Domains whose appearance varies across the visible
+                                    # state set are resolved on-device, so send no icon
+                                    # unless the user set an explicit override.
+                                    - variables:
+                                        resolved_on_device: >
+                                          {{
+                                            entity_id.split(".")[0] in
+                                            ["alarm_control_panel", "climate", "cover", "lock", "water_heater"]
+                                          }}
+
+                                    # Resolve the icon for the state in which the
+                                    # component is shown, not for the current state.
+                                    - variables:
+                                        forced_icon_state: 'on'
+                                    - *variable_entity
+                                    - variables:
+                                        sub_device_class: '{{ entity_device_class | default("", true) }}'
+                                        sub_icon_on: '{{ "" if resolved_on_device and not overlap_icon_valid else entity.icon }}'
+
+                                    - variables:
+                                        forced_icon_state: 'off'
+                                    - *variable_entity
+                                    - variables:
+                                        sub_icon_off: '{{ "" if resolved_on_device and not overlap_icon_valid else entity.icon }}'
+
+                                    - action: 'esphome.{{ action_prefix }}_api_subscribe'
+                                      data:
+                                        page: '{{ repeat.item.page }}'
+                                        component: '{{ repeat.item.component }}'
+                                        entity: '{{ entity_id }}'
+                                        device_class: '{{ sub_device_class }}'
+                                        icon_on: '{{ sub_icon_on }}'
+                                        icon_off: '{{ sub_icon_off }}'
+                                        color_on: '{{ repeat.item.icon_color_rgb if icon_color_rgb_valid else nextion.color.on }}'
+                                        color_off: '{{ repeat.item.icon_color_rgb if icon_color_rgb_valid else nextion.color.off }}'
+                                        inverted: '{{ repeat.item.inverted | default(false) }}'
+                                      continue_on_error: true
+                                    - *delay_default
+
+                              - action: 'esphome.{{ action_prefix }}_api_subscribe_end'
+                                data:
+                                  count: >
+                                    {{
+                                      api_subscriptions
+                                      | selectattr("entity", "search", "\\.")
+                                      | list | count
+                                    }}
+                                continue_on_error: true
 
                       - &variables_hardware
                         variables:
@@ -8194,90 +8257,7 @@ actions:
                                 continue_on_error: true
                               - *delay_default
 
-                          ###### Status / Chips bar ######
-                          - &update_chips_bar
-                            repeat:
-                              for_each: >
-                                {{
-                                  chips
-                                  | selectattr("entity", "defined")
-                                  | rejectattr("entity", "eq", [])
-                                  | list
-                                }}
-                              sequence:
-                                - &update_individual_chip
-                                  if: '{{ repeat.item.entity is defined and repeat.item.entity is string and repeat.item.entity.split(".") | count == 2 }}'
-                                  then:
-                                    - variables:
-                                        icon_color_rgb_valid: >
-                                          {{
-                                            repeat.item.icon_color_rgb is defined and
-                                            repeat.item.icon_color_rgb is list and
-                                            repeat.item.icon_color_rgb | count == 3
-                                          }}
-                                        entity_id: '{{ repeat.item.entity }}'
-                                        overlap:
-                                          icon: >
-                                            {{
-                                              repeat.item.icon
-                                              if
-                                                repeat.item.icon is defined and
-                                                repeat.item.icon is string and
-                                                repeat.item.icon | length > 0 and
-                                                repeat.item.icon is match "mdi:" and
-                                                repeat.item.icon.split("mdi:")[1] in all_icons
-                                              else
-                                                None
-                                            }}
-                                          icon_color: '{{ repeat.item.icon_color_rgb if icon_color_rgb_valid else None }}'
-                                    - *variable_entity
-                                    - condition: '{{ entity_has_value }}'
-                                    - variables:
-                                        entity_hvac_action: '{{ state_attr(entity_id, "hvac_action") | default("") if entity_domain == "climate" else "unknown" }}'
-                                        entity_state: >
-                                          {{
-                                            (entity_hvac_action if entity_hvac_action and entity_hvac_action not in enum.states.unknown else entity_state)
-                                            if entity_domain == "climate" else entity_state
-                                          }}
-                                        chip_visible: >
-                                          {{
-                                            (
-                                              (not repeat.item.inverted) and
-                                              (
-                                                (entity_state in enum.states.on) or
-                                                (entity_domain != "climate" and entity_domain in enum.states and entity_state in enum.states[entity_domain].on) or
-                                                (entity_domain == "climate" and entity_state in ["heating", "cooling", "drying", "fan_only"])
-                                              )
-                                            ) or
-                                            (
-                                              (repeat.item.inverted) and
-                                              (
-                                                (entity_state in enum.states.off) or
-                                                (entity_domain in enum.states and entity_state in enum.states[entity_domain].off) or
-                                                (entity_domain == "climate" and entity_state not in ["heating", "cooling", "drying", "fan_only"])
-                                              )
-                                            )
-                                          }}
-                                    - condition: '{{ entity.icon is defined and entity.icon is string and entity.icon | length > 0 }}'
-                                    - action: 'esphome.{{ action_prefix }}_icon'
-                                      data:
-                                        page: chips
-                                        id: '{{ repeat.item.component }}'
-                                        icon: '{{ entity.icon }}'
-                                        icon_color: >
-                                          {% if icon_color_rgb_valid %}
-                                            {{ repeat.item.icon_color_rgb }}
-                                          {% elif entity.icon_color is defined and
-                                                  entity.icon_color is list and
-                                                  entity.icon_color | count == 3 %}
-                                            {{ entity.icon_color }}
-                                          {% else %}
-                                            [255, 255, 255]
-                                          {% endif %}
-                                        visible: '{{ chip_visible }}'
-                                      continue_on_error: true
-                                    - *delay_default
-
+                          ###### Home page values ######
                           - repeat:
                               for_each: >
                                 {{
@@ -11843,22 +11823,6 @@ actions:
                   - '{{ trigger.entity_id is match "water_heater." }}'
                   - '{{ trigger.entity_id == detailed_entity_state }}'
                 sequence: *refresh_page_water_heater
-
-      - alias: Update chips bar
-        conditions:
-          - condition: trigger
-            id: trigger_chip_state
-        sequence:
-          - repeat:
-              for_each: >
-                {{
-                  chips
-                  | selectattr("entity", "defined")
-                  | selectattr("entity", "eq", trigger.entity_id)
-                  | list
-                }}
-              sequence:
-                - *update_individual_chip
 
       - alias: Update climate page
         conditions:


### PR DESCRIPTION
## What changed

Until now, every time an entity shown on a chip changed state, Home Assistant had to run the NSPanel Easy automation, work out what the chip should look like, and send the result to the panel. A motion sensor in a busy hallway could do that hundreds of times a day.

Chips now work differently. When the panel starts, it tells Home Assistant which entities it cares about. Home Assistant then sends those state changes straight to the panel, and the panel decides what to draw on its own. The automation is no longer involved.

Nothing changes in how you configure chips. The same Blueprint settings work exactly as before.

## Why

Three reasons.

The automation was doing a lot of repetitive work for very little. Every chip state change meant an automation run, a trace stored in Home Assistant's database, and an entry in the logbook. On a panel with a few active sensors that adds up quickly, and it competes with everything else Home Assistant is doing.

Chips were also slower than they needed to be. The old path meant a state change travelled to the automation, through the icon logic, and back out to the panel. Now it goes to the panel directly.

Finally, this is the first step towards moving more of the panel's display logic onto the panel itself. Buttons, labels and values will follow the same route in later releases.

## What you should notice

Chips update faster. Your automation traces and logbook get much quieter. Home Assistant does less work in the background, which matters most on a Raspberry Pi or a system running several panels.

## What you might notice, and shouldn't worry about

**The panel restarts once after you change a chip entity.** This is expected. Home Assistant only accepts subscription requests while a device is connecting, so a newly chosen entity cannot take effect until the panel reconnects. Changing a chip's icon, colour or inverted setting does not cause a restart, only changing which entity it points at.

**Chips are blank for a second or two after a restart.** The panel waits for Home Assistant to tell it what to draw. This is brief and normal.

**Covers now show movement.** A garage door or blind chip shows an amber arrow while it is opening or closing, then settles on its resting icon. This is new, and applies whether or not the chip is inverted.

**Some chips may show a different icon than before.** A few icon and state rules were corrected in the process. Alarm panels armed in night mode now show a chip at all, which they previously did not. Water heater chips now respond to their operation mode.

## Risks

This is a substantial rewrite of how chips work, and it is new. Please read this part.

**Chips are the only thing affected.** Buttons, values, entity pages, the climate page and everything else are untouched and work exactly as before. If something goes wrong, it will be limited to the chip bar.

**Numeric sensor chips do not currently work.** A chip pointed at a sensor showing a number, such as a temperature, will stay hidden. This is a known gap and will be addressed. If you rely on one, hold off on updating.

**Report anything that looks wrong.** Particularly: a chip that stays hidden when it should be visible, a chip showing the wrong icon, or a panel that restarts repeatedly. When reporting, please include which entity the chip points at and its domain, that is almost always enough to identify the cause.

**If a panel restarts in a loop**, that is the one failure mode worth acting on immediately. It should not happen, the panel is built to stop and keep working with its last known settings rather than loop, but if it does, remove the entities from your chips in the Blueprint, save, and open an issue.

## Updating

Update the ESPHome firmware and the Blueprint together. Neither works correctly without the other in this release.

## Links

- Resolves #297
- Helps with #259
- Helps with #267

## Summary by Sourcery

Introduce a Home Assistant API subscription engine and migrate NSPanel chip rendering to be driven directly by entity state subscriptions instead of Blueprint automation pushes.

New Features:
- Add ESPHome API subscription support that binds Home Assistant entities directly to panel components for local state-driven rendering.
- Enable NSPanel chips to update based on direct Home Assistant state subscriptions, with on-device state classification and icon/color resolution for multi-state domains.

Enhancements:
- Refactor chip handling so subscription-driven chips ignore Blueprint-driven updates and share persisted appearance across reboots.
- Improve brightness capability detection for lights by also checking the brightness attribute alongside supported color modes.

Build:
- Wire the NSPanel Easy ESPHome component to the Nextion display instance and include the new API subscription package in the core ESPHome configuration.

Documentation:
- Document the new API subscription actions and engine behaviour, including configuration, state classification, appearance resolution, and troubleshooting, and cross-link from existing API and chips documentation.

## Summary by Sourcery

Drive NSPanel chips from direct Home Assistant state subscriptions instead of per-state Blueprint automation runs, and introduce the supporting ESPHome subscription engine and documentation.

New Features:
- Add an ESPHome API subscription engine that binds Home Assistant entities directly to NSPanel components for local, state-driven rendering.
- Enable NSPanel chips to be updated from Home Assistant state subscriptions, with on-device state classification and icon/color resolution for multi-state domains.

Enhancements:
- Refactor chip handling so subscription-driven chips ignore Blueprint pushes and share persisted appearance across reboots.
- Improve light brightness capability detection by also considering the entity brightness attribute and supported color modes.

Build:
- Wire the NSPanel Easy ESPHome component to the Nextion display instance and include the new API subscription package in the core ESPHome configuration.
- Make the minimum required blueprint version track the firmware version for this subscription-enabled release.

Documentation:
- Document the new API subscription actions, engine behaviour, state classification, and appearance resolution, and reference them from existing API and chip documentation.
- Add user-facing guidance on the experimental subscription flow, limits, and troubleshooting steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent Home Assistant entity subscriptions for live NSPanel updates.
  * Added subscription-driven chips with state-based visibility, icons, colors, and brightness.
  * Added actions for registering and completing subscription updates.
  * Added support for alarm, climate, cover, lock, water-heater, and generic entities.
  * Added Nextion display integration for NSPanel Easy.

* **Documentation**
  * Added setup, lifecycle, limits, and troubleshooting guidance.

* **Bug Fixes**
  * Corrected buzzer package configuration and made the minimum Blueprint version dynamic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->