### PR TITLE
feat: Honor the entity's own color attribute when coloring entity icons

### DIFF
--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -6730,8 +6730,17 @@ actions:
           entity_state_is_unknown: '{{ ((not entity_state_is_on) and (not entity_state_is_off)) if entity_id_valid }}'
           entity_icon_color_tmp: >
             {%- if entity_id_valid -%}
-              {%- set default_color = overlap.icon_color if overlap_icon_color_valid else nextion.color.on -%}
-              {{ default_color if (not entity_state_is_off and not entity_state_is_unknown) else nextion.color.off }}
+              {%- set entity_color_attr = state_attr(entity_id, "color") | default("") -%}
+              {%- if entity_color_attr is string and entity_color_attr is match "#[0-9a-fA-F]{6}$" -%}
+                {%- set own_color = [entity_color_attr[1:3] | int(base=16), entity_color_attr[3:5] | int(base=16), entity_color_attr[5:7] | int(base=16)] -%}
+              {%- elif entity_color_attr is list and entity_color_attr | count == 3 -%}
+                {%- set own_color = entity_color_attr -%}
+              {%- else -%}
+                {%- set own_color = none -%}
+              {%- endif -%}
+              {%- set default_color = own_color if own_color is not none else (overlap.icon_color if overlap_icon_color_valid else nextion.color.on) -%}
+              {%- set has_explicit_color = own_color is not none or overlap_icon_color_valid -%}
+              {{ default_color if (entity_state_is_on or (has_explicit_color and not entity_state_is_off and entity_state not in enum.states.unknown)) else nextion.color.off }}
             {%- else -%}
               {{ overlap.icon_color if overlap_icon_color_valid else [0, 0, 0] }}
             {%- endif -%}


### PR DESCRIPTION
## What

In `entity_icon_color_tmp` (the generic icon-color path, used directly by all domains without dedicated color logic and as the fallback for `alarm_control_panel`, `climate`, `light`, `lock`, `timer` and `water_heater`):

- Read the entity's own `color` attribute — either a `#RRGGBB` hex string or a 3-element RGB list — and use it as the default icon color, taking precedence over the color configured in the blueprint (`overlap.icon_color`).
- Stop discarding an explicitly set color (entity attribute or blueprint config) when the state is neither in the "on" nor the "off" bucket. Those unclassified-but-valid states — every `select`/`input_select` option, for instance — were previously painted with the OFF color even when a color was explicitly configured.
- Truly uninformative states (`enum.states.unknown`: `unknown`, `unavailable`, none, empty) and off states still fall back to the OFF color, as before. Unclassified states with no explicit color also keep the previous behavior (OFF color).

## Why

The previous condition `not entity_state_is_off and not entity_state_is_unknown` reduces to `entity_state_is_on`, so a configured icon color could only ever show for states classified as "on". Domains whose states are not binary (selects, scenes, …) never matched, making the configured color unreachable for them. This PR separates "state carrying no information" (unknown/unavailable → OFF color) from "state the on/off lists cannot classify" (keep the explicit color).

## Validation

- `yamllint -c .rules/yamllint.yml nspanel_easy_blueprint.yaml` passes.
- Full YAML parse and Jinja syntax check of the modified block pass.

## Summary by Sourcery

Honor an entity's own color attribute when determining generic icon colors, while preserving OFF color behavior for unknown or uninformative states.

New Features:
- Support using an entity's `color` attribute (hex or RGB list) as the default icon color in the generic icon-color path.

Bug Fixes:
- Ensure explicitly configured icon colors are respected for non-binary and unclassified states instead of defaulting to the OFF color.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon color selection to honor an entity’s explicitly configured color.
  * Added support for six-digit hex colors and three-value RGB color lists.
  * Color selection now prioritizes the entity color, followed by overlap color and the default active color.
  * Icons use the off color for inactive states unless another color is explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->