### PR TITLE
fix: Panels no longer restart in a loop after changing entities

### DIFF
--- a/components/nspanel_easy/api_subscriptions.cpp
+++ b/components/nspanel_easy/api_subscriptions.cpp
@@ -363,6 +363,17 @@ void sub_push_binding(const char *page, const char *component, const char *entit
 }
 
 bool sub_persist(bool verified) {
+  // Three-phase write. Chunk keys are reused, so a failure partway through the
+  // loop would leave some chunks new and some old while the header still
+  // described the old set -- a reboot would then load a mixture. Publishing an
+  // empty header first means any later failure leaves the panel with no
+  // bindings: visibly wrong, but never silently inconsistent.
+  const SubHeader invalid{SUB_FORMAT_VERSION, 0, sub_unverified};
+  if (!sub_header_pref().save(&invalid) || !global_preferences->sync()) {
+    ESP_LOGE(TAG, "Could not invalidate the stored header; leaving the saved set untouched");
+    return false;  // Nothing was written, so the previous set is still coherent
+  }
+
   const uint16_t chunks = (sub_staged + SUB_CHUNK_SIZE - 1) / SUB_CHUNK_SIZE;
   bool ok = true;
 
@@ -381,7 +392,7 @@ bool sub_persist(bool verified) {
       global_preferences->sync();
       if (!sub_chunk_pref(chunk).save(&data)) {
         ok = false;
-        break;  // Further chunks would leave the persisted set inconsistent
+        break;  // The header stays empty, so the partial set is never loaded
       }
     }
   }  // for each chunk
@@ -396,6 +407,9 @@ bool sub_persist(bool verified) {
   if (!global_preferences->sync()) {
     ok = false;
   } else if (ok) {
+    // Only once the header has actually reached NVS: a counter advanced for a
+    // commit that never landed would eventually trip SUB_MAX_UNVERIFIED_COMMITS
+    // and start refusing valid pushes.
     sub_unverified = committed_unverified;
   }
 
@@ -404,8 +418,9 @@ bool sub_persist(bool verified) {
     // is an unrecoverable boot loop. The panel keeps the previously loaded
     // bindings instead: wrong, but stable and diagnosable.
     ESP_LOGE(TAG,
-             "Could not persist %" PRIu16 " binding(s); the panel will keep using the previously saved set. "
-             "This usually means the NVS partition is full or fragmented; a factory reset of the panel clears it.",
+             "Could not persist %" PRIu16 " binding(s); the stored set is now empty and the panel will "
+             "subscribe to nothing after the next reboot. This usually means the NVS partition is full or "
+             "fragmented; a factory reset of the panel clears it.",
              sub_staged);
     return false;
   }

--- a/components/nspanel_easy/api_subscriptions.cpp
+++ b/components/nspanel_easy/api_subscriptions.cpp
@@ -9,6 +9,7 @@
 #include <cinttypes>
 
 #include <esp_heap_caps.h>
+#include <nvs.h>
 
 #include "esphome/components/api/api_server.h"
 #include "esphome/core/application.h"
@@ -82,7 +83,6 @@ static ESPPreferenceObject sub_header_pref() {
  * @brief Preference handle for one binding chunk.
  *
  * Chunking keeps the compare-before-write copy in ESP32Preferences::is_changed()
- * small: one chunk is under 2 KB, where a single blob would be roughly 14 KB.
  *
  * @param chunk Chunk index.
  * @return Preference object for SubChunk.
@@ -362,8 +362,10 @@ void sub_push_binding(const char *page, const char *component, const char *entit
   }  // for each live binding
 }
 
-void sub_persist(bool verified) {
+bool sub_persist(bool verified) {
   const uint16_t chunks = (sub_staged + SUB_CHUNK_SIZE - 1) / SUB_CHUNK_SIZE;
+  bool ok = true;
+
   for (uint16_t chunk = 0; chunk < chunks; ++chunk) {
     SubChunk data{};
     for (uint16_t slot = 0; slot < SUB_CHUNK_SIZE; ++slot) {
@@ -372,15 +374,44 @@ void sub_persist(bool verified) {
         data.bindings[slot] = sub_staging[idx];
       }
     }
-    sub_chunk_pref(chunk).save(&data);
+    if (!sub_chunk_pref(chunk).save(&data)) {
+      ESP_LOGW(TAG, "Chunk %" PRIu16 " failed to save; retrying after a sync", chunk);
+      // A sync flushes pending writes, which can release space that a rewrite
+      // of an existing key needs before the old copy can be dropped.
+      global_preferences->sync();
+      if (!sub_chunk_pref(chunk).save(&data)) {
+        ok = false;
+        break;  // Further chunks would leave the persisted set inconsistent
+      }
+    }
   }  // for each chunk
 
-  sub_unverified = verified ? 0 : static_cast<uint8_t>(sub_unverified + 1);
-  SubHeader header{SUB_FORMAT_VERSION, sub_staged, sub_unverified};
-  sub_header_pref().save(&header);
-  global_preferences->sync();
+  if (ok) {
+    const uint8_t unverified = verified ? 0 : static_cast<uint8_t>(sub_unverified + 1);
+    const SubHeader header{SUB_FORMAT_VERSION, sub_staged, unverified};
+    ok = sub_header_pref().save(&header);
+    if (ok) {
+      sub_unverified = unverified;
+    }
+  }
+
+  if (!global_preferences->sync()) {
+    ok = false;
+  }
+
+  if (!ok) {
+    // Never schedule a restart here. A restart on a write that cannot succeed
+    // is an unrecoverable boot loop. The panel keeps the previously loaded
+    // bindings instead: wrong, but stable and diagnosable.
+    ESP_LOGE(TAG,
+             "Could not persist %" PRIu16 " binding(s); the panel will keep using the previously saved set. "
+             "This usually means the NVS partition is full or fragmented; a factory reset of the panel clears it.",
+             sub_staged);
+    return false;
+  }
 
   ESP_LOGI(TAG, "Persisted %" PRIu16 " binding(s)%s", sub_staged, verified ? "" : " (unverified)");
+  return true;
 }
 
 /**
@@ -427,8 +458,7 @@ bool sub_push_end(uint16_t count) {
       return false;
     }
     ESP_LOGI(TAG, "All bindings cleared");
-    sub_persist(true);
-    return true;
+    return sub_persist(true);
   }  // if empty push
 
   if (!sub_pushing) {
@@ -449,9 +479,9 @@ bool sub_push_end(uint16_t count) {
     return false;
   }
 
-  sub_persist(true);
+  const bool persisted = sub_persist(true);
   sub_push_release();
-  return true;
+  return persisted;
 }
 
 bool sub_push_timeout() {
@@ -475,9 +505,9 @@ bool sub_push_timeout() {
   }
 
   ESP_LOGW(TAG, "No end marker; committing %" PRIu16 " binding(s) unverified", sub_staged);
-  sub_persist(false);
+  const bool persisted = sub_persist(false);
   sub_push_release();
-  return true;
+  return persisted;
 }
 
 void sub_render_all() {
@@ -496,6 +526,11 @@ void sub_dump_config() {
     const SubBinding &binding = sub_bindings[idx];
     ESP_LOGCONFIG(TAG, "  %s.%s <- %s%s%s", binding.page, binding.component, binding.entity,
                   binding.inverted ? " (inverted)" : "", sub_renderers[idx] == nullptr ? " [no renderer]" : "");
+  }
+  nvs_stats_t nvs{};
+  if (nvs_get_stats(nullptr, &nvs) == ESP_OK) {
+    ESP_LOGCONFIG(TAG, "  NVS entries: %zu used, %zu free of %zu", nvs.used_entries, nvs.free_entries,
+                  nvs.total_entries);
   }
 }
 

--- a/components/nspanel_easy/api_subscriptions.cpp
+++ b/components/nspanel_easy/api_subscriptions.cpp
@@ -386,17 +386,17 @@ bool sub_persist(bool verified) {
     }
   }  // for each chunk
 
+  uint8_t committed_unverified = sub_unverified;
   if (ok) {
-    const uint8_t unverified = verified ? 0 : static_cast<uint8_t>(sub_unverified + 1);
-    const SubHeader header{SUB_FORMAT_VERSION, sub_staged, unverified};
+    committed_unverified = verified ? 0 : static_cast<uint8_t>(sub_unverified + 1);
+    const SubHeader header{SUB_FORMAT_VERSION, sub_staged, committed_unverified};
     ok = sub_header_pref().save(&header);
-    if (ok) {
-      sub_unverified = unverified;
-    }
   }
 
   if (!global_preferences->sync()) {
     ok = false;
+  } else if (ok) {
+    sub_unverified = committed_unverified;
   }
 
   if (!ok) {

--- a/components/nspanel_easy/api_subscriptions.h
+++ b/components/nspanel_easy/api_subscriptions.h
@@ -571,7 +571,12 @@ bool sub_push_end(uint16_t count);
 bool sub_push_timeout();
 
 /**
- * @brief Persist the staged set and clear the unverified-commit counter.
+ * @brief Persist the staged set.
+ *
+ * Written in three phases -- empty header, chunks, real header -- so that a
+ * failure part-way through leaves the stored set empty rather than a mixture of
+ * old and new chunks. The unverified-commit counter only advances once the
+ * header has reached NVS.
  *
  * @param verified Whether the push was confirmed by a matching end marker.
  * @return true when every chunk and the header reached NVS.

--- a/components/nspanel_easy/api_subscriptions.h
+++ b/components/nspanel_easy/api_subscriptions.h
@@ -36,7 +36,7 @@
 namespace esphome::nspanel_easy {
 
 /// @brief Persisted format version. Bump whenever SubBinding's layout changes.
-static constexpr uint8_t SUB_FORMAT_VERSION = 1;
+static constexpr uint8_t SUB_FORMAT_VERSION = 2;  // 2: chunk size reduced from 16 to 4
 
 /// @brief Upper bound on bindings; storage is allocated to the configured count, not this.
 #ifndef NSPANEL_EASY_SUB_MAX
@@ -44,8 +44,16 @@ static constexpr uint8_t SUB_FORMAT_VERSION = 1;
 #endif  // NSPANEL_EASY_SUB_MAX
 static constexpr uint16_t SUB_MAX = NSPANEL_EASY_SUB_MAX;
 
-/// @brief Bindings per persisted NVS chunk. Keeps the sync() compare-copy spike small.
-static constexpr uint16_t SUB_CHUNK_SIZE = 16;
+/**
+ * @brief Bindings per persisted NVS chunk.
+ *
+ * Deliberately small. NVS stores each preference as a single blob and needs
+ * room for the new copy before releasing the old, so a large blob can fail with
+ * ESP_ERR_NVS_NOT_ENOUGH_SPACE on a partition that is merely fragmented rather
+ * than full. At 4 bindings a chunk is under 512 bytes, which fits comfortably
+ * inside one NVS page; at 16 it was roughly 1.8 KB.
+ */
+static constexpr uint16_t SUB_CHUNK_SIZE = 4;
 
 /// @brief Number of NVS chunks needed to hold SUB_MAX bindings.
 static constexpr uint16_t SUB_CHUNK_COUNT = (SUB_MAX + SUB_CHUNK_SIZE - 1) / SUB_CHUNK_SIZE;
@@ -564,7 +572,7 @@ bool sub_push_timeout();
  *
  * @param verified Whether the push was confirmed by a matching end marker.
  */
-void sub_persist(bool verified);
+bool sub_persist(bool verified);
 
 /// @brief Re-render every binding from its last known state.
 void sub_render_all();

--- a/components/nspanel_easy/api_subscriptions.h
+++ b/components/nspanel_easy/api_subscriptions.h
@@ -551,8 +551,10 @@ void sub_push_binding(const char *page, const char *component, const char *entit
  *
  * @param count Number of bindings the blueprint sent. A mismatch discards the
  *              push and leaves the persisted set untouched.
- * @return true when the staged set differs from the persisted one and a restart
- *         is required.
+ * @return true when the staged set differs from the persisted one, was saved
+ *         successfully, and a restart is therefore required. false when nothing
+ *         changed, the push was rejected, or the save failed -- restarting on an
+ *         unpersisted set would reload the old bindings and loop forever.
  */
 bool sub_push_end(uint16_t count);
 
@@ -563,7 +565,8 @@ bool sub_push_end(uint16_t count);
  * SUB_MAX_UNVERIFIED_COMMITS consecutive unverified commits, so a systematically
  * failing push cannot produce a boot loop.
  *
- * @return true when a restart is required.
+ * @return true when the set was saved and a restart is required. See
+ *         sub_push_end() for why a failed save must not restart.
  */
 bool sub_push_timeout();
 
@@ -571,6 +574,7 @@ bool sub_push_timeout();
  * @brief Persist the staged set and clear the unverified-commit counter.
  *
  * @param verified Whether the push was confirmed by a matching end marker.
+ * @return true when every chunk and the header reached NVS.
  */
 bool sub_persist(bool verified);
 

--- a/docs/api_subscribe.md
+++ b/docs/api_subscribe.md
@@ -63,6 +63,8 @@ stored, and arrives with every push.
    bindings are staged.
 4. **Commit.** If the staged set differs from the persisted one, the panel saves it and restarts.
    If it matches, nothing happens — which is the normal case on every reconnect.
+   If the save fails, the panel does **not** restart: it keeps the bindings it loaded at boot.
+   A restart on a set that was never saved would reload the old bindings and repeat indefinitely.
 5. **Steady state.** Home Assistant pushes state changes. The panel renders them. No automation
    runs.
 
@@ -326,3 +328,11 @@ previous bindings are still in effect. Check whether any `api_subscribe` call is
 Three consecutive pushes arrived without an end marker. Verify that the automation is calling
 `api_subscribe_end` after the last binding. The panel keeps running its last good set until this is
 resolved.
+
+### `Could not persist` in the log
+
+The bindings could not be written to NVS, so the panel is still running the set it loaded at boot
+and your changes have not taken effect. The NVS partition is full or fragmented; a factory reset of
+the panel clears it. The entry counts in `dump_config` show whether the partition is genuinely too
+small, which happens on panels first flashed with much older firmware — those need to be flashed
+over USB once.

--- a/docs/api_subscribe.md
+++ b/docs/api_subscribe.md
@@ -332,7 +332,7 @@ resolved.
 ### `Could not persist` in the log
 
 The bindings could not be written to NVS, so the panel is still running the set it loaded at boot
-and your changes have not taken effect. The NVS partition is full or fragmented; a factory reset of
+and your changes have not taken effect. The NVS partition can be full or fragmented; a factory reset of
 the panel clears it. The entry counts in `dump_config` show whether the partition is genuinely too
 small, which happens on panels first flashed with much older firmware — those need to be flashed
 over USB once.

--- a/esphome/nspanel_esphome_hw_memory.yaml
+++ b/esphome/nspanel_esphome_hw_memory.yaml
@@ -20,6 +20,10 @@ substitutions:
   memory_dump_details: false
   MEMORY_DUMP_DETAILS_: ${ 1 if memory_dump_details else 0 }
 
+button:
+  - platform: factory_reset
+    name: Factory reset
+
 esp32:
   framework:
     advanced:
@@ -28,6 +32,10 @@ esp32:
 esphome:
   build_flags:
     - -D NSPANEL_EASY_HW_MEMORY
+
+factory_reset:
+  resets_required: 10
+  max_delay: 10s
 
 nspanel_easy:
   psram_clk_pin: ${GPIO_PSRAM_CLK_PIN}

--- a/esphome/nspanel_esphome_hw_memory.yaml
+++ b/esphome/nspanel_esphome_hw_memory.yaml
@@ -21,8 +21,11 @@ substitutions:
   MEMORY_DUMP_DETAILS_: ${ 1 if memory_dump_details else 0 }
 
 button:
-  - platform: factory_reset
+  - id: bt_factory_reset
     name: Factory reset
+    platform: factory_reset
+    disabled_by_default: true
+    internal: false
 
 esp32:
   framework:

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -6,7 +6,7 @@
 ##################################################################################################
 ---
 blueprint:
-  name: NSPanel Easy Configuration (v2026.8.5)
+  name: NSPanel Easy Configuration (v9999.99.9)
   author: Edward Firmo (https://github.com/edwardtfn)
   description: >
     # NSPanel Easy Configuration via Blueprint
@@ -4711,7 +4711,7 @@ trigger_variables:
 
 variables:
   # Version will be following release version defined automatically when merging to main
-  blueprint_version: 2026.8.5
+  blueprint_version: 9999.99.9
 
   pages:
     current: '{{ states(currentpage) }}'

--- a/prebuilt/nspanel_esphome_prebuilt.yaml
+++ b/prebuilt/nspanel_esphome_prebuilt.yaml
@@ -32,11 +32,6 @@ api:
         - lambda: ESP_LOGE("prebuilt.api.action.firmware_update", "Firmware update failed!");
 
 button:
-  - name: Factory reset
-    platform: factory_reset
-    disabled_by_default: true
-    internal: false
-
   - id: bt_firmware_update
     name: Firmware update
     platform: template


### PR DESCRIPTION
Some panels restarted over and over after entities were added or changed, never finishing start-up. The panel could not save its list of entities, and retried by restarting — which could never succeed.

Panels now keep working with their previous list instead of restarting, and the list is saved in smaller pieces so it fits where it did not before.

If your panel was affected, it should start normally after updating. If it still cannot save, the log now explains why, and the panel keeps running with whatever it last saved rather than restarting.

A small number of panels first set up with much older firmware have less storage available than current ones. Those may need to be flashed over USB once to get the current storage layout; the diagnostic information needed to tell is now included in the panel's start-up log.

## Links

- Helps with #371

## Summary by Sourcery

Prevent entity binding updates from causing restart loops by making persistence failure-safe and keeping panels running with their last successfully loaded configuration.

Bug Fixes:
- Prevent panels from restarting in a loop when entity binding persistence fails by retaining the bindings loaded at boot and only restarting after a successful save.
- Improve binding persistence reliability by storing smaller chunks and using failure-safe commits that avoid loading partially written data.

Enhancements:
- Add NVS usage statistics to startup configuration logs and clarify recovery guidance for persistence failures.

Documentation:
- Document that failed binding saves no longer trigger restarts and explain how to diagnose and recover from NVS capacity or fragmentation issues.

Chores:
- Expose a disabled factory-reset control in the hardware-memory configuration and centralize its reset settings.
- Update the persisted subscription format version for the revised chunk layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable factory-reset button requiring 10 activations within 10 seconds.
  * Updated subscription storage for more compact binding data.

* **Bug Fixes**
  * Improved reliability of subscription saves with retries and validation.
  * Prevented incomplete saves from replacing existing bindings.
  * Failed saves now report errors and avoid unnecessary restarts.
  * Save results are accurately reported.

* **Diagnostics**
  * Configuration dumps now show storage usage when available.
  * Expanded troubleshooting guidance for failed saves and full storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->