### PR TITLE
fix: Stop writing home page components after leaving the page

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Set up yq
         if: steps.skip_check.outputs.skip == 'false'
-        uses: mikefarah/yq@v4.53.3
+        uses: mikefarah/yq@v4.53.6
 
       - name: Get PR information
         id: pr_info

--- a/components/nspanel_easy/page_home.cpp
+++ b/components/nspanel_easy/page_home.cpp
@@ -21,8 +21,6 @@
 
 namespace esphome::nspanel_easy {
 
-bool is_home_page = false;
-
 #ifdef NSPANEL_EASY_SUBSCRIBE
 
 static const char *const TAG = "nspanel.page.home.sub";
@@ -128,9 +126,9 @@ static void home_button_render(const SubBinding &binding, const SubRuntime &rt, 
   button.color = color;
 
   ESP_LOGV(TAG, "%s: icon='%s' color=%" PRIu16 " home=%s appearance=%s", binding.component, icon, color,
-           YESNO(is_home_page), YESNO(rt.has_appearance));
+           YESNO(is_home_page()), YESNO(rt.has_appearance));
 
-  if (!is_home_page) {
+  if (!is_home_page()) {
     return;  // Shadow is up to date; the repaint on entry will draw it
   }
   if (icon_changed) {
@@ -253,7 +251,7 @@ static void home_indoor_temp_render(const char *state) {
   strncpy(indoor_temp_text, text, sizeof(indoor_temp_text) - 1);
   indoor_temp_text[sizeof(indoor_temp_text) - 1] = '\0';
 
-  if (!is_home_page) {
+  if (!is_home_page()) {
     return;  // Shadow is up to date; the repaint on entry will draw it
   }
   nextion_display->set_component_text(hmi::home::INDR_TEMP.name, indoor_temp_text);
@@ -278,7 +276,7 @@ static void home_outdoor_temp_render(const char *state) {
     if (strcmp(outdoor_temp_text, text) != 0) {
       strncpy(outdoor_temp_text, text, sizeof(outdoor_temp_text) - 1);
       outdoor_temp_text[sizeof(outdoor_temp_text) - 1] = '\0';
-      if (is_home_page) {
+      if (is_home_page()) {
         nextion_display->set_component_text(hmi::home::OUTDOOR_TEMP.name, outdoor_temp_text);
       }
     }
@@ -295,7 +293,7 @@ static void home_outdoor_temp_render(const char *state) {
   // The TFT restores visibility from vis_<component> on page entry, so the
   // variable is always written; the vis command only reaches a visible page.
   nextion_display->send_command_printf("vis_outdoor_temp=%" PRIu8, static_cast<uint8_t>(visible));
-  if (is_home_page) {
+  if (is_home_page()) {
     nextion_display->set_component_visibility("outdoor_temp", visible);
   }
 }
@@ -332,7 +330,7 @@ void home_button_repaint() {
     ESP_LOGE(TAG, "Missing Nextion display pointer");
     return;
   }
-  if (!is_home_page) {
+  if (!is_home_page()) {
     return;  // Unscoped names resolve against the visible page only
   }
 

--- a/components/nspanel_easy/page_home.h
+++ b/components/nspanel_easy/page_home.h
@@ -41,7 +41,7 @@
 
 namespace esphome::nspanel_easy {
 
-extern bool is_home_page;
+inline bool is_home_page() { return current_page_id == get_page_id("home"); }
 
 /// @brief Number of custom button slots on the home page (button01..button07).
 static constexpr uint8_t HOME_BUTTON_COUNT = 7;

--- a/esphome/nspanel_esphome_page_home.yaml
+++ b/esphome/nspanel_esphome_page_home.yaml
@@ -207,12 +207,21 @@ script:
     then:
       # Extended by:
       # - hw_relays
+      # - hw_temperature
       # - hw_wifi
+      # Give the Nextion time to finish constructing the page before repainting.
+      # Commands arriving while it is still drawing can overrun its receive
+      # buffer and be silently discarded.
       - delay: ${home_repaint_delay}
       - lambda: |-
-          // Repaint home page custom buttons (only when using subscriptions)
+          // Navigation during the delay leaves this script writing to whatever page
+          // is now displayed, so the check is here rather than in each extension.
+          if (!is_home_page()) {
+            page_home->stop();
+            return;
+          }
           #ifdef NSPANEL_EASY_SUBSCRIBE
-          home_button_repaint();
+          home_button_repaint();  // Repaint home page custom buttons
           #endif  // NSPANEL_EASY_SUBSCRIBE
 
   - id: !extend stop_all

--- a/esphome/nspanel_esphome_page_home.yaml
+++ b/esphome/nspanel_esphome_page_home.yaml
@@ -12,7 +12,7 @@ substitutions:
   ## Change only in your      ##
   ## local yaml substitutions ##
   TAG_PAGE_HOME: nspanel.page.home
-  home_repaint_delay: 250ms
+  home_repaint_delay: 10ms
   SUN_DEFAULT_LATITUDE: '0'
   SUN_DEFAULT_LONGITUDE: '0'
   ##############################
@@ -199,8 +199,7 @@ script:
   - id: !extend page_change
     then:
       - lambda: |-
-          is_home_page = (new_page_id == get_page_id("home"));
-          if (!is_home_page) return;
+          if (!is_home_page()) return;
           page_home->execute();
 
   - id: page_home

--- a/esphome/nspanel_esphome_page_home.yaml
+++ b/esphome/nspanel_esphome_page_home.yaml
@@ -12,6 +12,7 @@ substitutions:
   ## Change only in your      ##
   ## local yaml substitutions ##
   TAG_PAGE_HOME: nspanel.page.home
+  home_repaint_delay: 250ms
   SUN_DEFAULT_LATITUDE: '0'
   SUN_DEFAULT_LONGITUDE: '0'
   ##############################
@@ -208,6 +209,7 @@ script:
       # Extended by:
       # - hw_relays
       # - hw_wifi
+      - delay: ${home_repaint_delay}
       - lambda: |-
           // Repaint home page custom buttons (only when using subscriptions)
           #ifdef NSPANEL_EASY_SUBSCRIBE

--- a/esphome/nspanel_esphome_version.yaml
+++ b/esphome/nspanel_esphome_version.yaml
@@ -14,7 +14,7 @@ substitutions:
   # Minimum required blueprint version for compatibility
   # Select 'next' or '${version}' when you change the "contract" between ESPHome and Blueprint
   # Versioning workflow will replace this by the new version being generated
-  min_blueprint_version: 2026.8.8
+  min_blueprint_version: ${version}
 
   # Minimum required TFT version for compatibility
   # Must be manually updated with Nextion Editor

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -6,7 +6,7 @@
 ##################################################################################################
 ---
 blueprint:
-  name: NSPanel Easy Configuration (v2026.8.8)
+  name: NSPanel Easy Configuration (v9999.99.9)
   author: Edward Firmo (https://github.com/edwardtfn)
   description: >
     # NSPanel Easy Configuration via Blueprint
@@ -4733,7 +4733,7 @@ trigger_variables:
 variables:
   # Blueprint version will be following release version defined automatically when merging to main
   # There's no need to change it here
-  blueprint_version: 2026.8.8
+  blueprint_version: 9999.99.9
 
   # Firmware version as reported by the ESPHome integration in the device registry.
   # Format: "<project_version> (ESPHome <compiler_version>)", e.g. "2026.8.5 (ESPHome 2026.6.0)".


### PR DESCRIPTION
## Summary by Sourcery

Prevent stale home-page updates from reaching other pages during navigation by validating the active page before rendering.

Bug Fixes:
- Prevent home-page repaint and component updates from writing to the display after navigation away from the home page.
- Allow delayed home-page repainting to be cancelled when navigation occurs during page construction.

Enhancements:
- Determine home-page visibility from the current page identifier instead of maintaining separate state.

Build:
- Update the versioning workflow's yq action and align blueprint version placeholders with the release version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable delay before refreshing the home screen, with a default of 10 ms.
  * Home-screen updates now include temperature information and safely stop if navigation occurs during refresh.

* **Bug Fixes**
  * Improved home-screen detection and repaint handling during page transitions.

* **Chores**
  * Updated blueprint versioning and minimum-version handling.
  * Updated the automated versioning tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->