### PR TITLE
fix: Show the QR code button again

### DIFF
--- a/esphome/nspanel_esphome_page_home.yaml
+++ b/esphome/nspanel_esphome_page_home.yaml
@@ -159,6 +159,9 @@ script:
           // full boot path.
           boot_nextion->execute();
           home_vis_resend();
+          #ifdef NSPANEL_EASY_USE_WEATHER
+          home_weather_resolve();
+          #endif  // NSPANEL_EASY_USE_WEATHER
           #ifdef NSPANEL_EASY_SUBSCRIBE
           home_button_repaint();
           #endif  // NSPANEL_EASY_SUBSCRIBE

--- a/esphome/nspanel_esphome_page_qrcode.yaml
+++ b/esphome/nspanel_esphome_page_qrcode.yaml
@@ -51,9 +51,8 @@ api:
             if (qrcode.empty() and !id(qrcode_string).empty()) {
               ESP_LOGD("${TAG_PAGE_QRCODE}", "QR code empty");
               id(qrcode_string) = qrcode;
-              disp1->send_command("vis_bt_qrcode=0");
+              action_component_visibility->execute("home", "bt_qrcode", false);
               if (current_page_id == home_page_id) {
-                disp1->hide_component(hmi::home::BT_QRCODE.name);
                 return;
               }
               if (current_page_id == qrcode_page_id) {
@@ -72,7 +71,7 @@ api:
             }
 
             if (data_changed) {
-              disp1->send_command("vis_bt_qrcode=1");
+              action_component_visibility->execute("home", "bt_qrcode", true);
             }
 
             if (data_changed and current_page_id == qrcode_page_id) {

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -6,7 +6,7 @@
 ##################################################################################################
 ---
 blueprint:
-  name: NSPanel Easy Configuration (v2026.9.2)
+  name: NSPanel Easy Configuration (v9999.99.9)
   author: Edward Firmo (https://github.com/edwardtfn)
   description: >
     # NSPanel Easy Configuration via Blueprint
@@ -4739,7 +4739,7 @@ trigger_variables:
 variables:
   # Blueprint version will be following release version defined automatically when merging to main
   # There's no need to change it here
-  blueprint_version: 2026.9.2
+  blueprint_version: 9999.99.9
 
   # Firmware version as reported by the ESPHome integration in the device registry.
   # Format: "<project_version> (ESPHome <compiler_version>)", e.g. "2026.8.5 (ESPHome 2026.6.0)".


### PR DESCRIPTION
The QR code button disappeared from the home page. The button's visibility was still being set through a variable that was replaced in the last release, so the setting never reached the display and the button stayed hidden even when a QR code was configured.

Also in this release

- The weather picture is redrawn if the display restarts on its own, instead of staying blank until the forecast next changes.

If you were affected, no configuration change is needed — updating is enough.

## Summary by Sourcery

Restore QR code controls and refresh weather content after display restarts.

Bug Fixes:
- Restore QR code button visibility by routing QR code state changes through the shared component-visibility handling.
- Redraw the weather display after an unexpected display restart so it no longer remains blank until the forecast changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Weather information now refreshes correctly after the display resynchronizes.
  - QR-code buttons now reliably hide when no QR code is available and appear when QR-code data is provided.

- **Chores**
  - Updated the blueprint version metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->