### PR TITLE
feat: Add require confirmation for Home page custom buttons

### DIFF
--- a/components/nspanel_easy/hw_display.cpp
+++ b/components/nspanel_easy/hw_display.cpp
@@ -16,6 +16,8 @@ uint8_t display_mode_eeprom = UINT8_MAX;  // Populated from boot report, UINT8_M
 bool display_portrait = false;
 bool display_valid = false;
 
+ClickInterceptor click_interceptor;
+
 }  // namespace esphome::nspanel_easy
 
 #endif  // NSPANEL_EASY_HW_DISPLAY

--- a/components/nspanel_easy/hw_display.h
+++ b/components/nspanel_easy/hw_display.h
@@ -5,6 +5,8 @@
 #ifdef NSPANEL_EASY_HW_DISPLAY
 
 #include <cstdint>
+#include <functional>
+#include <string>
 #include <vector>
 #include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
@@ -31,6 +33,23 @@ extern bool display_entity_keep;
 extern uint8_t display_mode_eeprom;
 extern bool display_portrait;
 extern bool display_valid;
+
+/**
+ * @brief Optional local handler for a click, tried before it reaches Home Assistant.
+ *
+ * Assigned from a page package that needs to act on a click itself rather than
+ * forward it, currently the home page routing a custom button through the
+ * confirmation dialog. Returning true consumes the event; whatever handled it
+ * is responsible for re-emitting the click if the user goes ahead.
+ *
+ * @param page Page that produced the event, as reported by the display.
+ * @param event "short_click" or "long_click".
+ * @param component Unscoped component name, e.g. "button01".
+ * @return true when the click was handled locally and must not reach Home Assistant.
+ */
+using ClickInterceptor =
+    std::function<bool(const std::string &page, const std::string &event, const std::string &component)>;
+extern ClickInterceptor click_interceptor;
 
 }  // namespace esphome::nspanel_easy
 

--- a/components/nspanel_easy/page_home.cpp
+++ b/components/nspanel_easy/page_home.cpp
@@ -4,6 +4,7 @@
 
 #include "page_home.h"
 
+#include <cctype>
 #include <cinttypes>
 
 #include "esphome/components/nextion/nextion.h"
@@ -13,7 +14,6 @@
 
 #ifdef NSPANEL_EASY_SUBSCRIBE
 
-#include <cctype>
 #include <cstdio>
 
 #include "esphome/core/helpers.h"
@@ -25,6 +25,23 @@
 namespace esphome::nspanel_easy {
 
 static const char *const TAG = "nspanel.page.home";
+
+uint8_t parse_home_button_index(const char *component) {
+  constexpr uint8_t PREFIX_LEN = 6;  // strlen("button")
+  if (strlen(component) != PREFIX_LEN + 2 || strncmp(component, "button", PREFIX_LEN) != 0) {
+    return UINT8_MAX;
+  }
+  const char tens = component[PREFIX_LEN];
+  const char units = component[PREFIX_LEN + 1];
+  if (!std::isdigit(static_cast<unsigned char>(tens)) || !std::isdigit(static_cast<unsigned char>(units))) {
+    return UINT8_MAX;
+  }
+  const uint8_t number = static_cast<uint8_t>(((tens - '0') * 10) + (units - '0'));
+  if (number < 1 || number > HOME_BUTTON_COUNT) {
+    return UINT8_MAX;
+  }
+  return static_cast<uint8_t>(number - 1);
+}
 
 uint32_t home_vis_mask = 0;
 
@@ -89,33 +106,6 @@ static char outdoor_temp_text[TEMP_TEXT_LEN] = {};
 
 /// @brief Whether the outdoor temperature component is currently shown.
 static Visibility outdoor_temp_shown = Visibility::UNKNOWN;
-
-/**
- * @brief Parse the slot index out of a custom button component name.
- *
- * Used by home_sub_render() as a probe: a component that is not a custom button
- * is an ordinary outcome here, so no warning is emitted. The dispatcher warns
- * once, after every target has been tried.
- *
- * @param component Component name, expected as "button%02u".
- * @return Zero-based index into home_button_states[], or UINT8_MAX if invalid.
- */
-static uint8_t parse_home_button_index(const char *component) {
-  constexpr uint8_t PREFIX_LEN = 6;  // strlen("button")
-  if (strlen(component) != PREFIX_LEN + 2 || strncmp(component, "button", PREFIX_LEN) != 0) {
-    return UINT8_MAX;
-  }
-  const char tens = component[PREFIX_LEN];
-  const char units = component[PREFIX_LEN + 1];
-  if (!std::isdigit(static_cast<unsigned char>(tens)) || !std::isdigit(static_cast<unsigned char>(units))) {
-    return UINT8_MAX;
-  }
-  const uint8_t number = static_cast<uint8_t>(((tens - '0') * 10) + (units - '0'));
-  if (number < 1 || number > HOME_BUTTON_COUNT) {
-    return UINT8_MAX;
-  }
-  return static_cast<uint8_t>(number - 1);
-}
 
 /**
  * @brief Build the scoped Nextion name for a home custom button.

--- a/components/nspanel_easy/page_home.h
+++ b/components/nspanel_easy/page_home.h
@@ -72,6 +72,18 @@ void home_vis_resend();
 /// @brief Number of custom button slots on the home page (button01..button07).
 static constexpr uint8_t HOME_BUTTON_COUNT = 7;
 
+/**
+ * @brief Parse the slot index out of a custom button component name.
+ *
+ * Used as a probe by both the subscription renderer and the confirmation gate:
+ * a component that is not a custom button is an ordinary outcome here, so no
+ * warning is emitted. Callers report on their own terms.
+ *
+ * @param component Component name, expected as "button%02u".
+ * @return Zero-based slot index, or UINT8_MAX if the name is not a custom button.
+ */
+uint8_t parse_home_button_index(const char *component);
+
 #ifdef NSPANEL_EASY_SUBSCRIBE
 
 /**

--- a/esphome/nspanel_esphome_hw_display.yaml
+++ b/esphome/nspanel_esphome_hw_display.yaml
@@ -270,6 +270,12 @@ script:
                 return;
               }
 
+              // A page package may claim the click, e.g. to ask for confirmation
+              if (click_interceptor and click_interceptor(page, event, params[2])) {
+                ESP_LOGD("${TAG_HW_DISPLAY}", "%s handled locally", event.c_str());
+                return;
+              }
+
               // Button click event
               ESP_LOGD("${TAG_HW_DISPLAY}", "%s->HA", event.c_str());
               fire_ha_event("button_click", {

--- a/esphome/nspanel_esphome_page_home.yaml
+++ b/esphome/nspanel_esphome_page_home.yaml
@@ -54,6 +54,13 @@ globals:
     restore_value: true
     initial_value: '8'
 
+  # One bit per custom button slot, bit 0 = button01. Persisted so a reboot
+  # cannot expose an unconfirmed button until the blueprint pushes again.
+  - id: home_confirm_mask
+    type: uint8_t
+    restore_value: true
+    initial_value: '0'
+
 script:
   - id: !extend action_component_color
     then:
@@ -97,6 +104,11 @@ script:
             id(is_climate) = (val != 0);
             return;
           }
+          if (component == "custom_buttons_confirm") {
+            // Custom buttons requiring confirmation
+            id(home_confirm_mask) = static_cast<uint8_t>(val);
+            return;
+          }
           if (component == "custom_buttons_font") {
             // Custom buttons icon size
             id(home_custom_buttons_font_id) = static_cast<uint8_t>(val);
@@ -135,6 +147,33 @@ script:
           // Other components icons size and color
           disp1->set_component_font(hmi::home::BT_ENTITIES.name, id(home_custom_buttons_font_id));
           disp1->set_component_font(hmi::home::WIFI_ICON.name,   id(chip_font_id));
+
+          // Route custom button clicks through the confirmation dialog when the
+          // blueprint asked for it. Only short clicks act on the entity; a long
+          // click opens the detailed page and needs no confirmation.
+          #ifdef NSPANEL_EASY_PAGE_CONFIRM
+          click_interceptor = [](const std::string &page,
+                                 const std::string &event,
+                                 const std::string &component) -> bool {
+            if (page != "home") return false;
+            if (event != "short_click") return false;
+            // The confirm page re-emits the accepted click while it is still
+            // showing, so the guard below is what stops it looping back here.
+            if (current_page_id != get_page_id("home")) return false;
+
+            const uint8_t slot = parse_home_button_index(component.c_str());
+            if (slot == UINT8_MAX) return false;
+            if ((id(home_confirm_mask) & (1U << slot)) == 0) return false;
+
+            ESP_LOGD("${TAG_PAGE_HOME}", "%s requires confirmation", component.c_str());
+            disp1->set_component_text("confirm.page_name", "home");
+            disp1->set_component_text("confirm.component", component.c_str());
+            disp1->set_component_text("confirm.body", "");  // Global component, may hold a button page label
+            disp1->set_component_value("confirm.page_id", get_page_id("home"));
+            goto_page->execute(get_page_id("confirm"));
+            return true;
+          };
+          #endif  // NSPANEL_EASY_PAGE_CONFIRM
 
   - id: !extend boot_wrap_up
     then:

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -6,7 +6,7 @@
 ##################################################################################################
 ---
 blueprint:
-  name: NSPanel Easy Configuration (v2026.9.5)
+  name: NSPanel Easy Configuration (v9999.99.9)
   author: Edward Firmo (https://github.com/edwardtfn)
   description: >
     # NSPanel Easy Configuration via Blueprint
@@ -536,6 +536,13 @@ blueprint:
           default: ""
           selector:
             text:
+        home_custom_button01_confirm:
+          name: Home page - Custom button 1 - Require confirmation
+          default: false
+          description: &description_ask_for_confirmation >
+            When enabled, a confirmation dialog will be shown before the action is executed.
+          selector:
+            boolean:
         home_custom_button02:
           name: Home page - Custom button 2 - Entity
           description: *description_home_custom_button_entity
@@ -552,6 +559,12 @@ blueprint:
           default: ""
           selector:
             text:
+        home_custom_button02_confirm:
+          name: Home page - Custom button 2 - Require confirmation
+          default: false
+          description: *description_ask_for_confirmation
+          selector:
+            boolean:
         home_custom_button03:
           name: Home page - Custom button 3 - Entity
           description: *description_home_custom_button_entity
@@ -568,6 +581,12 @@ blueprint:
           default: ""
           selector:
             text:
+        home_custom_button03_confirm:
+          name: Home page - Custom button 3 - Require confirmation
+          default: false
+          description: *description_ask_for_confirmation
+          selector:
+            boolean:
         home_custom_button04:
           name: Home page - Custom button 4 - Entity
           description: *description_home_custom_button_entity
@@ -584,6 +603,12 @@ blueprint:
           default: ""
           selector:
             text:
+        home_custom_button04_confirm:
+          name: Home page - Custom button 4 - Require confirmation
+          default: false
+          description: *description_ask_for_confirmation
+          selector:
+            boolean:
         home_custom_button05:
           name: Home page - Custom button 5 - Entity
           description: *description_home_custom_button_entity
@@ -600,6 +625,12 @@ blueprint:
           default: ""
           selector:
             text:
+        home_custom_button05_confirm:
+          name: Home page - Custom button 5 - Require confirmation
+          default: false
+          description: *description_ask_for_confirmation
+          selector:
+            boolean:
         home_custom_button06:
           name: Home page - Custom button 6 - Entity
           description: *description_home_custom_button_entity
@@ -616,6 +647,12 @@ blueprint:
           default: ""
           selector:
             text:
+        home_custom_button06_confirm:
+          name: Home page - Custom button 6 - Require confirmation
+          default: false
+          description: *description_ask_for_confirmation
+          selector:
+            boolean:
         alarm:  # This key was kept with this name to support inputs from legacy versions where the alarm was the only option at that button
           name: Home page - Custom button 7 - Entity
           description: *description_home_custom_button_entity
@@ -632,6 +669,12 @@ blueprint:
           default: ""
           selector:
             text:
+        home_custom_button07_confirm:
+          name: Home page - Custom button 7 - Require confirmation
+          default: false
+          description: *description_ask_for_confirmation
+          selector:
+            boolean:
     home_page_general_settings:
       name: Home page - General settings
       icon: mdi:home
@@ -1547,8 +1590,7 @@ blueprint:
         entity01_confirm:
           name: Button page 1, Button 1 - Require confirmation
           default: false
-          description: &description_ask_for_confirmation >
-            When enabled, a confirmation dialog will be shown before the action is executed.
+          description: *description_ask_for_confirmation
           selector:
             boolean:
         entity01_custom_action:
@@ -4739,7 +4781,7 @@ trigger_variables:
 variables:
   # Blueprint version will be following release version defined automatically when merging to main
   # There's no need to change it here
-  blueprint_version: 2026.9.5
+  blueprint_version: 9999.99.9
 
   # Firmware version as reported by the ESPHome integration in the device registry.
   # Format: "<project_version> (ESPHome <compiler_version>)", e.g. "2026.8.5 (ESPHome 2026.6.0)".
@@ -7394,6 +7436,31 @@ actions:
                               val: !input custom_buttons_font_size
                             continue_on_error: true
                           - *delay_boot
+                          - alias: custom_buttons_confirm
+                            sequence:
+                              - variables:
+                                  home_custom_buttons_confirm:
+                                    - !input home_custom_button01_confirm
+                                    - !input home_custom_button02_confirm
+                                    - !input home_custom_button03_confirm
+                                    - !input home_custom_button04_confirm
+                                    - !input home_custom_button05_confirm
+                                    - !input home_custom_button06_confirm
+                                    - !input home_custom_button07_confirm
+                              - action: 'esphome.{{ action_prefix }}_component_val'
+                                data:
+                                  page: mem
+                                  id: custom_buttons_confirm
+                                  val: >
+                                    {% set ns = namespace(decimal_value = 0) %}
+                                    {% for confirm_item in home_custom_buttons_confirm %}
+                                        {% if (confirm_item) %}
+                                            {% set ns.decimal_value = ns.decimal_value + (2 ** loop.index0) %}
+                                        {% endif %}
+                                    {% endfor %}
+                                    {{ ns.decimal_value }}
+                                continue_on_error: true
+                              - *delay_boot
                           - alias: Temperatures appearance
                             sequence:
                               - variables:


### PR DESCRIPTION
Home page custom buttons can now ask for confirmation before acting, the same way button page buttons already do.

Each of the seven custom buttons has its own **Require confirmation** switch in the Blueprint. When it is on, tapping the button opens the confirmation dialog and the action only runs after you accept it. This is meant for buttons you do not want triggered by accident, such as a script that feeds your pets or opens a gate.

Long clicks are unaffected: they open the entity's detailed page, where nothing happens until you interact with it.

Closes #243

## Summary by Sourcery

Add optional confirmation dialogs for Home page custom-button actions to prevent accidental activation.

New Features:
- Add independent confirmation settings for all seven Home page custom buttons.
- Require confirmation before executing configured short-click actions while preserving long-click navigation behavior.

Enhancements:
- Centralize click interception so page-specific interactions can consume display events before they are forwarded to Home Assistant.
- Persist Home page custom-button confirmation settings across reboots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional confirmation prompts for each of the seven Home page custom buttons.
  * Configured custom buttons to open the confirmation page before completing short-click actions when confirmation is enabled.
  * Added local click handling so intercepted clicks can be processed on the panel without sending a Home Assistant event.
  * Added support for configuring confirmation requirements through the blueprint inputs.

* **Enhancements**
  * Updated the blueprint version and display metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->