### PR TITLE
fix: Use non-action pattern for internal pseudo-actions to prevent HA validation errors

### DIFF
--- a/.github/workflows/esphome_build.yml
+++ b/.github/workflows/esphome_build.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
       - name: Build firmware
-        uses: esphome/build-action@v8.0.0
+        uses: esphome/build-action@v8.1.0
         with:
           yaml-file: ${{ matrix.firmware.yaml-file }}
           substitutions: |
@@ -182,7 +182,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
       - name: Build firmware
-        uses: esphome/build-action@v8.0.0
+        uses: esphome/build-action@v8.1.0
         with:
           yaml-file: ${{ matrix.firmware.yaml-file }}
           version: dev
@@ -210,7 +210,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
       - name: Build firmware
-        uses: esphome/build-action@v8.0.0
+        uses: esphome/build-action@v8.1.0
         with:
           yaml-file: ${{ matrix.firmware.yaml-file }}
           substitutions: |
@@ -257,7 +257,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
       - name: Build firmware
-        uses: esphome/build-action@v8.0.0
+        uses: esphome/build-action@v8.1.0
         with:
           yaml-file: ${{ matrix.firmware.yaml-file }}
           version: dev

--- a/esphome/nspanel_esphome_page_vacuum.yaml
+++ b/esphome/nspanel_esphome_page_vacuum.yaml
@@ -38,7 +38,7 @@ display:
             switch (component_id) {
               case 8:  // bt_start_pause — Blueprint resolves state and calls correct action
                 fire_ha_event("action_call", {
-                  {"action", is_mower ? "lawn_mower.start_pause_toggle" : "vacuum.start_pause_toggle"},
+                  {"action", is_mower ? "_lawn_mower_start_pause_toggle_" : "_vacuum_start_pause_toggle_"},
                   {"entity", entity.c_str()}
                 });
                 break;
@@ -51,17 +51,10 @@ display:
                 break;
 
               case 10:  // bt_return
-                if (is_mower) {
-                  fire_ha_event("action_call", {
-                    {"action", "lawn_mower.dock"},
-                    {"entity", entity.c_str()}
-                  });
-                } else {
-                  fire_ha_event("action_call", {
-                    {"action", "vacuum.return_to_base"},
-                    {"entity", entity.c_str()}
-                  });
-                }
+                fire_ha_event("action_call", {
+                  {"action", is_mower ? "lawn_mower.dock" : "vacuum.return_to_base"},
+                  {"entity", entity.c_str()}
+                });
                 break;
 
               default:

--- a/esphome/nspanel_esphome_version.yaml
+++ b/esphome/nspanel_esphome_version.yaml
@@ -14,7 +14,7 @@ substitutions:
   # Minimum required blueprint version for compatibility
   # Select 'next' or '${version}' when you change the "contract" between ESPHome and Blueprint
   # Versioning workflow will replace this by the new version being generated
-  min_blueprint_version: 2026.9.7
+  min_blueprint_version: ${version}
 
   # Minimum required TFT version for compatibility
   # Must be manually updated with Nextion Editor

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -6,7 +6,7 @@
 ##################################################################################################
 ---
 blueprint:
-  name: NSPanel Easy Configuration (v2026.9.7)
+  name: NSPanel Easy Configuration (v9999.99.9)
   author: Edward Firmo (https://github.com/edwardtfn)
   description: >
     # NSPanel Easy Configuration via Blueprint
@@ -4789,7 +4789,7 @@ trigger_variables:
 variables:
   # Blueprint version will be following release version defined automatically when merging to main
   # There's no need to change it here
-  blueprint_version: 2026.9.7
+  blueprint_version: 9999.99.9
 
   # Firmware version as reported by the ESPHome integration in the device registry.
   # Format: "<project_version> (ESPHome <compiler_version>)", e.g. "2026.8.5 (ESPHome 2026.6.0)".
@@ -8255,7 +8255,7 @@ actions:
                     else:
                       - choose:
                           - alias: Lawn mower start/pause toggle
-                            conditions: '{{ nspanel_event.action == "lawn_mower.start_pause_toggle" }}'
+                            conditions: '{{ nspanel_event.action == "_lawn_mower_start_pause_toggle_" }}'
                             sequence:
                               - action: >-
                                   {{ "lawn_mower.pause"
@@ -8265,7 +8265,7 @@ actions:
                                   entity_id: '{{ nspanel_event.entity }}'
                                 continue_on_error: true
                           - alias: Vacuum start/pause toggle
-                            conditions: '{{ nspanel_event.action == "vacuum.start_pause_toggle" }}'
+                            conditions: '{{ nspanel_event.action == "_vacuum_start_pause_toggle_" }}'
                             sequence:
                               - action: >-
                                   {{ "vacuum.pause"
@@ -8278,6 +8278,7 @@ actions:
                           - condition:
                               - '{{ nspanel_event.action is defined }}'
                               - '{{ nspanel_event.entity is defined }}'
+                              - '{{ "." in nspanel_event.action }}'
                           - action: '{{ nspanel_event.action }}'
                             target:
                               entity_id: '{{ nspanel_event.entity }}'

--- a/nspanel_easy_blueprint.yaml
+++ b/nspanel_easy_blueprint.yaml
@@ -8150,6 +8150,34 @@ actions:
                             continue_on_error: true
                           - *delay_boot
 
+              - alias: Lawn mower start/pause toggle
+                conditions:
+                  - '{{ nspanel_event.type == "action_call" }}'
+                  - '{{ nspanel_event.action == "_lawn_mower_start_pause_toggle_" }}'
+                  - '{{ nspanel_event.entity is defined }}'
+                sequence:
+                  - action: >-
+                      {{ "lawn_mower.pause"
+                        if states(nspanel_event.entity) in ["mowing", "returning"]
+                        else "lawn_mower.start_mowing" }}
+                    target:
+                      entity_id: '{{ nspanel_event.entity }}'
+                    continue_on_error: true
+
+              - alias: Vacuum start/pause toggle
+                conditions:
+                  - '{{ nspanel_event.type == "action_call" }}'
+                  - '{{ nspanel_event.action == "_vacuum_start_pause_toggle_" }}'
+                  - '{{ nspanel_event.entity is defined }}'
+                sequence:
+                  - action: >-
+                      {{ "vacuum.pause"
+                        if states(nspanel_event.entity) in ["cleaning", "returning"]
+                        else "vacuum.start" }}
+                    target:
+                      entity_id: '{{ nspanel_event.entity }}'
+                    continue_on_error: true
+
               - alias: NSPanel action call
                 conditions:
                   - '{{ nspanel_event.type == "action_call" }}'
@@ -8253,36 +8281,14 @@ actions:
                               entity_id: '{{ nspanel_event.entity }}'
                             continue_on_error: true
                     else:
-                      - choose:
-                          - alias: Lawn mower start/pause toggle
-                            conditions: '{{ nspanel_event.action == "_lawn_mower_start_pause_toggle_" }}'
-                            sequence:
-                              - action: >-
-                                  {{ "lawn_mower.pause"
-                                    if states(nspanel_event.entity) in ["mowing", "returning"]
-                                    else "lawn_mower.start_mowing" }}
-                                target:
-                                  entity_id: '{{ nspanel_event.entity }}'
-                                continue_on_error: true
-                          - alias: Vacuum start/pause toggle
-                            conditions: '{{ nspanel_event.action == "_vacuum_start_pause_toggle_" }}'
-                            sequence:
-                              - action: >-
-                                  {{ "vacuum.pause"
-                                    if states(nspanel_event.entity) in ["cleaning", "returning"]
-                                    else "vacuum.start" }}
-                                target:
-                                  entity_id: '{{ nspanel_event.entity }}'
-                                continue_on_error: true
-                        default:
-                          - condition:
-                              - '{{ nspanel_event.action is defined }}'
-                              - '{{ nspanel_event.entity is defined }}'
-                              - '{{ "." in nspanel_event.action }}'
-                          - action: '{{ nspanel_event.action }}'
-                            target:
-                              entity_id: '{{ nspanel_event.entity }}'
-                            continue_on_error: true
+                      - condition:
+                          - '{{ nspanel_event.action is defined }}'
+                          - '{{ nspanel_event.entity is defined }}'
+                          - '{{ "." in nspanel_event.action }}'
+                      - action: '{{ nspanel_event.action }}'
+                        target:
+                          entity_id: '{{ nspanel_event.entity }}'
+                        continue_on_error: true
                   - delay:
                       milliseconds: '{{ media_player_update_delay }}'
                   - condition:


### PR DESCRIPTION
Replaces the `domain.service` naming pattern used for internal Blueprint pseudo-actions with a `_domain_service_` format that cannot be mistaken for real Home Assistant actions or entities.

This prevents HA's automation validator and Spook from flagging these internal event identifiers as unknown actions or ghost entities, and adds a guard to skip any action call that does not contain a `.` in its name.

## Links

- Resolves #416

## Summary by Sourcery

Separate internal pseudo-actions from Home Assistant action identifiers to avoid validation errors while retaining device-specific start/pause behavior.

Bug Fixes:
- Prevent internal Blueprint pseudo-actions from being interpreted as Home Assistant actions or entities during validation.
- Skip action calls whose identifiers are not valid domain.service actions.

Enhancements:
- Handle lawn mower and vacuum start/pause toggles through dedicated internal event identifiers while preserving normal return and docking actions.

Build:
- Upgrade the ESPHome build action used by firmware workflows to v8.1.0.

Chores:
- Use generated version placeholders for the blueprint and minimum compatibility versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved vacuum and lawn-mower controls so start, pause, and return-to-base actions work consistently across supported entity types.
  - Updated action matching and validation to handle supported action formats more reliably.
  - Kept the minimum required blueprint version synchronized with the current release version.

- **Chores**
  - Updated the ESPHome build workflow to use a newer build action version.
  - Refreshed blueprint version metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->